### PR TITLE
Enhance terrain viewer object summaries

### DIFF
--- a/docs/terrain_overview.md
+++ b/docs/terrain_overview.md
@@ -1,0 +1,54 @@
+# Visão geral da montagem do terreno
+
+Este documento resume como o cliente monta e renderiza o terreno no projeto, com base no arquivo `source/ZzzLodTerrain.cpp`.
+
+## Estruturas principais
+
+O módulo de terreno mantém buffers globais para os dados de malha, atributos e iluminação, como altura, normais, camadas de texturas e marcações de colisão. Esses arrays são dimensionados para `TERRAIN_SIZE * TERRAIN_SIZE` e incluem buffers específicos para gramado e atributos especiais do mapa.【F:source/ZzzLodTerrain.cpp†L31-L57】
+
+Os índices dos tiles são calculados por utilitários como `TERRAIN_INDEX` (indexação direta) e `TERRAIN_INDEX_REPEAT` (indexação com wrap), enquanto `TERRAIN_ATTRIBUTE` traduz coordenadas do mundo para o valor de atributo da célula (`TerrainWall`).【F:source/ZzzLodTerrain.cpp†L72-L87】
+
+## Carregamento dos dados do mapa
+
+### Atributos
+
+`OpenTerrainAttribute` lê o arquivo de atributos (com encriptação Bux e `MapFileDecrypt`), preenche `TerrainWall` e valida algumas posições conhecidas para garantir integridade. Cada célula guarda flags como zonas de água, altura especial, bloqueios de movimento etc.【F:source/ZzzLodTerrain.cpp†L114-L210】 As funções `AddTerrainAttribute` e correlatas permitem editar essas flags em runtime.【F:source/ZzzLodTerrain.cpp†L228-L258】
+
+### Mapeamento de texturas
+
+`OpenTerrainMapping` abre o arquivo de mapeamento de texturas, também encriptado, preenchendo duas camadas (`TerrainMappingLayer1/2`) e um alpha por célula. Esse alpha decide se a segunda camada substitui a primeira e também controla a renderização de gramado. Há desativação opcional do gramado em mapas como Chaos Castle ou Battle Castle.【F:source/ZzzLodTerrain.cpp†L285-L329】
+
+### Altura
+
+`CreateTerrain` ativa o terreno e decide qual rotina de leitura usar (`OpenTerrainHeight` ou `OpenTerrainHeightNew`) conforme o formato do arquivo. No fim, chama `CreateSun` para preparar objetos visuais relacionados.【F:source/ZzzLodTerrain.cpp†L485-L499】
+
+* **Formato clássico:** `OpenTerrainHeight` lê um BMP compactado (`*.OZB`), copia o cabeçalho e converte cada pixel em altura, com um fator de escala diferente para o mapa de login.【F:source/ZzzLodTerrain.cpp†L513-L563】
+* **Formato estendido:** `OpenTerrainHeightNew` lê alturas codificadas em 24 bits, deslocando-as para o intervalo real adicionando `g_fMinHeight`. Esse formato cobre mapas novos/estendidos.【F:source/ZzzLodTerrain.cpp†L596-L639】
+
+Com os arrays preenchidos, funções utilitárias como `RequestTerrainHeight` interpolam a altura em tempo real e respeitam flags especiais como `TW_HEIGHT`, que força um "platô" alto (usado para paredes invisíveis, por exemplo).【F:source/ZzzLodTerrain.cpp†L649-L684】
+
+## Derivação de normais e iluminação
+
+Depois de carregar a altura, `CreateTerrainNormal` percorre cada célula e monta normais a partir dos quatro vértices adjacentes, permitindo iluminação suave. Existe também a versão parcial para recalcular regiões locais.【F:source/ZzzLodTerrain.cpp†L371-L409】
+
+`OpenTerrainLight` lê uma textura de luz (JPEG) e, após gerar as normais, chama `CreateTerrainLight` para combinar a textura com a direção da luz (diferente em alguns mapas, como Battle Castle). O resultado alimenta `BackTerrainLight`, usado diretamente na renderização.【F:source/ZzzLodTerrain.cpp†L411-L465】
+
+Funções auxiliares (`SetTerrainLight`, `AddTerrainLight`, etc.) espalham contribuições de luz em um raio usando um fator radial, possibilitando efeitos dinâmicos como sombras locais.【F:source/ZzzLodTerrain.cpp†L725-L756】
+
+## Pipeline de renderização
+
+A chamada principal `RenderTerrain` coordena a renderização. Ela ajusta animações de água (`WaterMove`), prepara o modo de blending e define `TerrainFlag` para renderizar primeiro o solo padrão e depois, opcionalmente, o gramado. Também inicializa seleção/edição quando necessário.【F:source/ZzzLodTerrain.cpp†L2455-L2504】
+
+`RenderTerrainFrustrum` percorre blocos 4x4 dentro dos limites do frustum pré-calculado, chamando `RenderTerrainBlock` para subdividir cada bloco em tiles individuais conforme o LOD atual. Isso evita desenhar tiles fora da visão.【F:source/ZzzLodTerrain.cpp†L2358-L2410】
+
+`RenderTerrainTile` monta os quatro vértices de um tile com base em `BackTerrainHeight`, ajusta alturas especiais (`TW_HEIGHT`) e delega a renderização real a `RenderTerrainFace`. Em modo de edição, a função também trata seleção e depuração de atributos; em modo normal, desenha o tile com a textura adequada e iluminação interpolada.【F:source/ZzzLodTerrain.cpp†L1552-L1670】
+
+Após o solo base, `RenderTerrainTile_After` e `RenderTerrainFace_After` desenham sobreposições como água transparente ou combinações de camadas, usando o alpha de mapeamento para decidir qual textura aplicar.【F:source/ZzzLodTerrain.cpp†L1526-L1697】 Finalmente, quando o gramado está ativo (`TerrainFlag == TERRAIN_MAP_GRASS`), os mesmos loops são reutilizados para renderizar o efeito animado de grama, deslocando vértices com `TerrainGrassWind` e texturas randômicas.【F:source/ZzzLodTerrain.cpp†L1499-L1517】【F:source/ZzzLodTerrain.cpp†L2494-L2499】
+
+## Ferramenta de visualização
+
+Para inspecionar rapidamente o resultado desse pipeline sem executar o cliente original, o repositório inclui o utilitário `tools/terrain_viewer/terrain_viewer.py`. Ele aplica as mesmas rotinas de descriptografia (`MapFileDecrypt` e `BuxConvert`) usadas nos carregadores de atributos, texturas e objetos, reconstrói o campo de altura e plota o terreno com os objetos estáticos em 3D utilizando Matplotlib.【F:tools/terrain_viewer/terrain_viewer.py†L1-L421】 O parser de objetos lê `EncTerrainXX.obj` exatamente como o cliente (`type_id`, posição XYZ, ângulos e escala), associa o identificador ao nome declarado em `_enum.h` e posiciona cada instância acima da altura interpolada no grid, emitindo um resumo textual dos tipos mais frequentes.【F:tools/terrain_viewer/terrain_viewer.py†L153-L239】【F:tools/terrain_viewer/terrain_viewer.py†L357-L406】【F:tools/terrain_viewer/README.md†L45-L74】 A ferramenta também oferece uma interface gráfica: basta selecionar a pasta `Data` e escolher o `WorldX` desejado em um menu drop-down; o rodapé da janela lista a contagem total de objetos e os IDs mais comuns, facilitando a exploração de múltiplos mapas sem lembrar caminhos específicos.【F:tools/terrain_viewer/terrain_viewer.py†L423-L575】【F:tools/terrain_viewer/README.md†L20-L37】 Consulte a documentação na própria pasta para detalhes de uso, incluindo o suporte a diretórios `ObjectX` externos e a opção `--enum-path` para apontar explicitamente para o `_enum.h` original do cliente.【F:tools/terrain_viewer/README.md†L76-L96】
+
+## Conclusão
+
+O terreno é montado em três etapas principais: leitura dos dados (altura, atributos e texturas), geração de informações derivadas (normais e luz) e renderização otimizada com frustum culling. O uso de arrays globais para cada aspecto do terreno permite que sistemas diferentes (colisão, efeitos, UI de edição) consultem ou modifiquem os dados conforme necessário.

--- a/tools/terrain_viewer/README.md
+++ b/tools/terrain_viewer/README.md
@@ -1,0 +1,87 @@
+# Terrain viewer
+
+Este utilitário em Python recria parte do pipeline de carregamento do terreno
+(altura, atributos, mapeamento de texturas e objetos estáticos) e gera uma
+visualização rápida usando o Matplotlib.
+
+## Pré-requisitos
+
+O script depende de Python 3.9+ com as bibliotecas abaixo:
+
+```bash
+pip install -r requirements.txt
+```
+
+O arquivo `requirements.txt` na pasta contém as dependências mínimas (NumPy e
+Matplotlib).
+
+## Como usar
+
+1. Extraia os arquivos do cliente em uma pasta acessível. Você precisará do
+   diretório `Data/WorldX` correspondente ao mapa que deseja visualizar com os
+   arquivos `EncTerrain*.att`, `EncTerrain*.map` e `TerrainHeight.OZB` (ou
+   `TerrainHeightNew.OZB`). Se os objetos estiverem separados em `Data/ObjectX`,
+   mantenha essa pasta acessível também.
+
+### Interface gráfica
+
+Execute o script sem argumentos (ou com `--gui`) para abrir uma janela que
+permite:
+
+1. Escolher a pasta `Data` por meio de um seletor de diretórios.
+2. Selecionar qual `WorldX` carregar usando um drop-down preenchido
+   automaticamente com base na pasta escolhida.
+3. Ajustar opções como `Map ID`, escala de altura, limite de objetos e, se
+   necessário, apontar explicitamente para uma pasta `ObjectX`.
+
+Ao clicar em **Visualizar**, o terreno e os objetos são carregados e exibidos.
+O rodapé da janela mostra um resumo com a contagem total de objetos e os tipos
+mais frequentes (com nomes extraídos do `_enum.h` do cliente). Também é
+possível gerar uma imagem PNG diretamente pelo botão **Salvar PNG**.
+
+### Linha de comando
+
+Caso prefira o modo tradicional, execute o script apontando para a pasta
+`WorldX` (e opcionalmente informe a pasta `ObjectX` com `--object-path`):
+
+```bash
+python terrain_viewer.py /caminho/para/Data/World1 --output world1.png
+```
+
+O comando acima gera um `PNG` com a visualização e também abre a janela do
+Matplotlib. Para apenas salvar a imagem, adicione `--no-show`. Caso o ID do mapa
+não esteja presente no nome da pasta, informe manualmente com `--map-id`. Se o
+arquivo `EncTerrain*.obj` estiver armazenado em `Data/ObjectX`, use
+`--object-path /caminho/para/Data/Object1`. O carregamento imprime um resumo dos
+objetos encontrados e, se desejar, é possível apontar explicitamente para o
+arquivo `_enum.h` do cliente com `--enum-path` para que os IDs sejam convertidos
+em nomes legíveis.
+
+### Opções principais
+
+- `--extended-height`: força o parser do formato novo de altura (24 bits) — a
+  mesma rotina `OpenTerrainHeightNew` usada pelo cliente.
+- `--max-objects`: limita a quantidade de objetos renderizados (útil em mapas
+  com milhares de instâncias).
+- `--object-path`: aponta diretamente para a pasta `ObjectX` quando os objetos
+  não estão junto do `WorldX`.
+- `--no-show`: evita abrir a janela interativa do Matplotlib.
+- `--output`: caminho do arquivo PNG de saída.
+- `--height-scale`: ajusta o fator aplicado ao formato clássico de altura (1.5
+  por padrão, use 3.0 para o mapa de login).
+- `--enum-path`: sobrescreve o caminho padrão de `_enum.h` usado para nomear os
+  modelos lidos de `EncTerrainXX.obj`.
+
+## Exemplo
+
+```bash
+python terrain_viewer.py /caminho/para/Data/World7 --max-objects 500 --output world7.png --no-show
+```
+
+O script decodifica os arquivos criptografados usando as mesmas rotinas inline
+(`MapFileDecrypt` e `BuxConvert`) vistas em `source/ZzzLodTerrain.cpp` e
+`source/ZzzObject.cpp`. O arquivo `EncTerrainXX.obj` é interpretado exatamente
+como no cliente: cada entrada informa o `type_id`, posição (`x`, `y`, `z`),
+ângulos (`pitch`, `yaw`, `roll`) e escala. As posições são convertidas para o
+mesmo espaço do terreno e plotadas acima da altura correspondente, garantindo
+que a visualização reproduza o cenário esperado do jogo.

--- a/tools/terrain_viewer/requirements.txt
+++ b/tools/terrain_viewer/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib>=3.5
+numpy>=1.23

--- a/tools/terrain_viewer/terrain_viewer.py
+++ b/tools/terrain_viewer/terrain_viewer.py
@@ -1,0 +1,881 @@
+"""Terrain visualization utility.
+
+Ferramenta em Python para visualizar o terreno e objetos estáticos em 3D.
+Ela reutiliza os mesmos formatos do cliente legado para gerar uma malha
+matricial e sobrepor os objetos com Matplotlib.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import functools
+import math
+import re
+import struct
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+TERRAIN_SIZE = 256
+TERRAIN_SCALE = 100.0
+BUX_CODE = (0xFC, 0xCF, 0xAB)
+MAP_XOR_KEY = (
+    0xD1,
+    0x73,
+    0x52,
+    0xF6,
+    0xD2,
+    0x9A,
+    0xCB,
+    0x27,
+    0x3E,
+    0xAF,
+    0x59,
+    0x31,
+    0x37,
+    0xB3,
+    0xE7,
+    0xA2,
+)
+G_MIN_HEIGHT = -500.0
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ENUM_PATH = REPO_ROOT / "source" / "_enum.h"
+
+MODEL_LINE_RE = re.compile(r"^(MODEL_[A-Z0-9_]+)\s*(?:=\s*([^,]+))?\s*,?$")
+CONST_LINE_RE = re.compile(r"^([A-Z0-9_]+)\s*=\s*([^,]+)\s*,?$")
+
+
+def _eval_int_expression(expr: str, env: Mapping[str, int]) -> int:
+    node = ast.parse(expr, mode="eval")
+
+    def _eval(parsed: ast.AST) -> int:
+        if isinstance(parsed, ast.Expression):
+            return _eval(parsed.body)
+        if isinstance(parsed, ast.Constant):
+            if isinstance(parsed.value, (int, float)):
+                return int(parsed.value)
+            raise ValueError(f"Valor constante inesperado: {parsed.value!r}")
+        if isinstance(parsed, ast.UnaryOp):
+            operand = _eval(parsed.operand)
+            if isinstance(parsed.op, ast.UAdd):
+                return +operand
+            if isinstance(parsed.op, ast.USub):
+                return -operand
+            raise ValueError(f"Operador unário não suportado: {parsed.op}")
+        if isinstance(parsed, ast.BinOp):
+            left = _eval(parsed.left)
+            right = _eval(parsed.right)
+            if isinstance(parsed.op, ast.Add):
+                return left + right
+            if isinstance(parsed.op, ast.Sub):
+                return left - right
+            if isinstance(parsed.op, ast.Mult):
+                return left * right
+            if isinstance(parsed.op, ast.FloorDiv):
+                return left // right
+            if isinstance(parsed.op, ast.LShift):
+                return left << right
+            if isinstance(parsed.op, ast.RShift):
+                return left >> right
+            if isinstance(parsed.op, ast.BitOr):
+                return left | right
+            if isinstance(parsed.op, ast.BitAnd):
+                return left & right
+            if isinstance(parsed.op, ast.BitXor):
+                return left ^ right
+            raise ValueError(f"Operador não suportado: {parsed.op}")
+        if isinstance(parsed, ast.Name):
+            if parsed.id not in env:
+                raise KeyError(parsed.id)
+            return int(env[parsed.id])
+        raise ValueError(f"Expressão não suportada: {ast.dump(parsed)}")
+
+    return _eval(node)
+
+
+@functools.lru_cache(maxsize=None)
+def load_model_names(enum_path: str) -> Dict[int, str]:
+    path = Path(enum_path)
+    if not path.exists():
+        return {}
+
+    env: Dict[str, int] = {"MAX_CLASS": 7}
+    names: Dict[int, str] = {}
+    current_value: Optional[int] = None
+    inside_world_section = False
+
+    with path.open(encoding="utf-8", errors="ignore") as handle:
+        for raw_line in handle:
+            line = raw_line.split("//", 1)[0].strip()
+            if not line:
+                continue
+
+            if not inside_world_section:
+                if line.startswith("MODEL_WORLD_OBJECT"):
+                    inside_world_section = True
+                else:
+                    continue
+
+            if line.startswith("//skill") or line.startswith("MODEL_SKILL_BEGIN"):
+                break
+
+            model_match = MODEL_LINE_RE.match(line)
+            if model_match:
+                name, expr = model_match.groups()
+                if expr is not None:
+                    value = _eval_int_expression(expr.strip(), env)
+                    current_value = value
+                else:
+                    if current_value is None:
+                        continue
+                    current_value += 1
+                    value = current_value
+                env[name] = value
+                names[value] = name
+                continue
+
+            const_match = CONST_LINE_RE.match(line)
+            if const_match:
+                const_name, expr = const_match.groups()
+                value = _eval_int_expression(expr.strip(), env)
+                env[const_name] = value
+                if const_name.startswith("MODEL_"):
+                    names[value] = const_name
+                current_value = value
+
+    return names
+
+
+@dataclass
+class TerrainData:
+    height: np.ndarray
+    mapping_layer1: np.ndarray
+    mapping_layer2: np.ndarray
+    mapping_alpha: np.ndarray
+    attributes: np.ndarray
+
+
+@dataclass
+class TerrainObject:
+    type_id: int
+    position: Tuple[float, float, float]
+    angles: Tuple[float, float, float]
+    scale: float
+    type_name: Optional[str] = None
+
+    @property
+    def tile_position(self) -> Tuple[float, float]:
+        return (self.position[0] / TERRAIN_SCALE, self.position[1] / TERRAIN_SCALE)
+
+
+@dataclass
+class TerrainLoadResult:
+    world_path: Path
+    data: TerrainData
+    objects: List[TerrainObject]
+    map_id: int
+    map_id_attribute: int
+    map_id_mapping: int
+    map_id_objects: int
+    model_names: Mapping[int, str]
+
+
+def map_file_decrypt(data: bytes) -> bytes:
+    """Reproduz a rotina inline MapFileDecrypt do cliente."""
+
+    xor_key = MAP_XOR_KEY
+    w_map_key = 0x5E
+    out = bytearray(len(data))
+    for idx, byte in enumerate(data):
+        decrypted = ((byte ^ xor_key[idx % len(xor_key)]) - w_map_key) & 0xFF
+        out[idx] = decrypted
+        w_map_key = (byte + 0x3D) & 0xFF
+    return bytes(out)
+
+
+def bux_convert(data: bytearray) -> None:
+    for idx in range(len(data)):
+        data[idx] ^= BUX_CODE[idx % len(BUX_CODE)]
+
+
+def _read_file(path: Path) -> bytes:
+    try:
+        return path.read_bytes()
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Arquivo não encontrado: {path}") from exc
+
+
+def open_terrain_attribute(path: Path) -> Tuple[int, np.ndarray]:
+    raw = _read_file(path)
+    decrypted = bytearray(map_file_decrypt(raw))
+    bux_convert(decrypted)
+
+    if len(decrypted) not in (131_076, 65_540):
+        raise ValueError(
+            "Tamanho inesperado para arquivo de atributos."
+            f" Esperado 65540 ou 131076 bytes, recebi {len(decrypted)}."
+        )
+
+    version = decrypted[0]
+    map_id = decrypted[1]
+    width = decrypted[2]
+    height = decrypted[3]
+    if version != 0 or width != 255 or height != 255:
+        raise ValueError(
+            "Cabeçalho de atributos inválido (versão, largura ou altura)."
+        )
+
+    offset = 4
+    if len(decrypted) == 65_540:
+        data = np.frombuffer(decrypted, dtype=np.uint8, count=TERRAIN_SIZE * TERRAIN_SIZE, offset=offset)
+        attributes = data.astype(np.uint16)
+    else:
+        data = np.frombuffer(decrypted, dtype=np.uint16, count=TERRAIN_SIZE * TERRAIN_SIZE, offset=offset)
+        attributes = data.copy()
+    return int(map_id), attributes.reshape((TERRAIN_SIZE, TERRAIN_SIZE))
+
+
+def open_terrain_mapping(path: Path) -> Tuple[int, np.ndarray, np.ndarray, np.ndarray]:
+    raw = _read_file(path)
+    decrypted = map_file_decrypt(raw)
+    ptr = 0
+    ptr += 1  # versão
+    map_id = decrypted[ptr]
+    ptr += 1  # número do mapa
+
+    layer_count = TERRAIN_SIZE * TERRAIN_SIZE
+    layer1 = np.frombuffer(decrypted, dtype=np.uint8, count=layer_count, offset=ptr)
+    ptr += layer_count
+    layer2 = np.frombuffer(decrypted, dtype=np.uint8, count=layer_count, offset=ptr)
+    ptr += layer_count
+    alpha_bytes = decrypted[ptr : ptr + layer_count]
+    alpha = np.frombuffer(alpha_bytes, dtype=np.uint8).astype(np.float32) / 255.0
+    return (
+        int(map_id),
+        layer1.reshape((TERRAIN_SIZE, TERRAIN_SIZE)),
+        layer2.reshape((TERRAIN_SIZE, TERRAIN_SIZE)),
+        alpha.reshape((TERRAIN_SIZE, TERRAIN_SIZE)),
+    )
+
+
+def load_height_file(path: Path, *, extended: bool = False, scale_override: Optional[float] = None) -> np.ndarray:
+    raw = _read_file(path)
+    if len(raw) < 4:
+        raise ValueError("Arquivo de altura muito pequeno.")
+    payload = raw[4:]
+
+    if not extended:
+        if len(payload) < 1080 + TERRAIN_SIZE * TERRAIN_SIZE:
+            raise ValueError("Arquivo de altura (formato clássico) truncado.")
+        height_bytes = payload[1080 : 1080 + TERRAIN_SIZE * TERRAIN_SIZE]
+        heights = np.frombuffer(height_bytes, dtype=np.uint8).astype(np.float32)
+        scale = scale_override if scale_override is not None else 1.5
+        heights *= scale
+    else:
+        header_size = 14 + 40
+        if len(payload) < header_size + TERRAIN_SIZE * TERRAIN_SIZE * 3:
+            raise ValueError("Arquivo de altura (formato estendido) truncado.")
+        pixel_data = payload[header_size : header_size + TERRAIN_SIZE * TERRAIN_SIZE * 3]
+        heights = np.empty(TERRAIN_SIZE * TERRAIN_SIZE, dtype=np.float32)
+        for idx in range(TERRAIN_SIZE * TERRAIN_SIZE):
+            b = pixel_data[idx * 3 + 0]
+            g = pixel_data[idx * 3 + 1]
+            r = pixel_data[idx * 3 + 2]
+            value = (r << 16) | (g << 8) | b
+            heights[idx] = float(value) + G_MIN_HEIGHT
+    return heights.reshape((TERRAIN_SIZE, TERRAIN_SIZE))
+
+
+def open_objects_enc(path: Path, model_names: Mapping[int, str]) -> Tuple[int, List[TerrainObject]]:
+    raw = _read_file(path)
+    decrypted = map_file_decrypt(raw)
+    ptr = 0
+    ptr += 1  # versão
+    map_id = decrypted[ptr]
+    ptr += 1  # número do mapa
+    count = struct.unpack_from("<h", decrypted, ptr)[0]
+    ptr += 2
+    objects: List[TerrainObject] = []
+    for _ in range(count):
+        type_id = struct.unpack_from("<h", decrypted, ptr)[0]
+        ptr += 2
+        position = struct.unpack_from("<3f", decrypted, ptr)
+        ptr += 12
+        angles = struct.unpack_from("<3f", decrypted, ptr)
+        ptr += 12
+        scale = struct.unpack_from("<f", decrypted, ptr)[0]
+        ptr += 4
+        objects.append(
+            TerrainObject(
+                type_id=type_id,
+                position=(position[0], position[1], position[2]),
+                angles=(angles[0], angles[1], angles[2]),
+                scale=scale,
+                type_name=model_names.get(type_id),
+            )
+        )
+    return int(map_id), objects
+
+
+def bilinear_height(height: np.ndarray, x: float, y: float) -> float:
+    xi = int(math.floor(x))
+    yi = int(math.floor(y))
+    if xi < 0 or yi < 0 or xi >= TERRAIN_SIZE - 1 or yi >= TERRAIN_SIZE - 1:
+        return float(height[min(max(yi, 0), TERRAIN_SIZE - 1), min(max(xi, 0), TERRAIN_SIZE - 1)])
+    xd = x - xi
+    yd = y - yi
+    h1 = height[yi, xi] * (1 - yd) + height[yi + 1, xi] * yd
+    h2 = height[yi, xi + 1] * (1 - yd) + height[yi + 1, xi + 1] * yd
+    return h1 * (1 - xd) + h2 * xd
+
+
+def render_scene(
+    data: TerrainData,
+    objects: Sequence[TerrainObject],
+    *,
+    output: Optional[Path],
+    show: bool,
+    max_objects: Optional[int],
+    title: Optional[str] = None,
+) -> None:
+    x = np.arange(TERRAIN_SIZE)
+    y = np.arange(TERRAIN_SIZE)
+    xx, yy = np.meshgrid(x, y)
+    heights = data.height
+
+    fig = plt.figure(figsize=(10, 7))
+    ax = fig.add_subplot(111, projection="3d")
+
+    cmap = plt.get_cmap("terrain")
+    face_colors = cmap((data.mapping_layer1.astype(np.float32) / 255.0))
+
+    ax.plot_surface(
+        xx,
+        yy,
+        heights,
+        rstride=2,
+        cstride=2,
+        facecolors=face_colors,
+        linewidth=0,
+        antialiased=False,
+        shade=False,
+    )
+
+    if objects:
+        used_objects = objects[:max_objects] if max_objects is not None else objects
+        ox = np.array([obj.tile_position[0] for obj in used_objects])
+        oy = np.array([obj.tile_position[1] for obj in used_objects])
+        oz = np.array([bilinear_height(heights, x, y) for x, y in zip(ox, oy)])
+        type_ids = np.array([obj.type_id for obj in used_objects], dtype=float)
+        if type_ids.size > 0 and type_ids.ptp() > 0:
+            colors = (type_ids - type_ids.min()) / type_ids.ptp()
+        else:
+            colors = np.zeros_like(type_ids)
+        ax.scatter(ox, oy, oz + 50.0, c=colors, cmap="tab20", s=10, depthshade=False)
+
+    ax.set_xlabel("X (tiles)")
+    ax.set_ylabel("Y (tiles)")
+    ax.set_zlabel("Altura")
+    ax.view_init(elev=60, azim=45)
+    if title:
+        ax.set_title(title)
+    plt.tight_layout()
+
+    if output:
+        fig.savefig(output)
+        print(f"Visualização salva em {output}")
+
+    if show:
+        plt.show()
+    else:
+        plt.close(fig)
+
+
+def find_first(pattern: str, directory: Path) -> Optional[Path]:
+    for candidate in sorted(directory.glob(pattern)):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def infer_map_id(world_path: Path) -> Optional[int]:
+    for part in world_path.parts[::-1]:
+        if part.lower().startswith("world"):
+            digits = "".join(ch for ch in part if ch.isdigit())
+            if digits:
+                return int(digits)
+    return None
+
+
+def guess_object_folder(world_path: Path) -> Optional[Path]:
+    name = world_path.name
+    lowered = name.lower()
+    if lowered.startswith("world"):
+        suffix = name[len("World") :]
+        candidate = world_path.parent / f"Object{suffix}"
+        if candidate.is_dir():
+            return candidate
+    # Também tente a variação com caixa baixa, caso o pacote use minúsculas.
+    if lowered.startswith("world"):
+        suffix = lowered[len("world") :]
+        candidate = world_path.parent / f"object{suffix}"
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def resolve_files(
+    world_path: Path, map_id: Optional[int], *, object_path: Optional[Path]
+) -> Tuple[Path, Path, Path, Path]:
+    if map_id is None:
+        map_id = infer_map_id(world_path)
+
+    def build_pattern(prefix: str, extension: str) -> str:
+        return f"{prefix}{map_id if map_id is not None else ''}{extension}"
+
+    mapping = find_first(build_pattern("EncTerrain", ".map"), world_path)
+    attributes = find_first(build_pattern("EncTerrain", ".att"), world_path)
+    if not mapping or not attributes:
+        raise FileNotFoundError(
+            "Não foi possível localizar arquivos .map/.att correspondentes no diretório informado."
+        )
+
+    object_dir_candidates: List[Path] = []
+    if object_path is not None:
+        if not object_path.is_dir():
+            raise FileNotFoundError(f"Diretório de objetos inválido: {object_path}")
+        object_dir_candidates.append(object_path)
+    object_guess = guess_object_folder(world_path)
+    if object_guess is not None:
+        object_dir_candidates.append(object_guess)
+    object_dir_candidates.append(world_path)
+
+    objects: Optional[Path] = None
+    for candidate in object_dir_candidates:
+        objects = find_first(build_pattern("EncTerrain", ".obj"), candidate)
+        if objects:
+            break
+    if not objects:
+        raise FileNotFoundError(
+            "Não foi possível localizar arquivo .obj correspondente."
+            " Informe --object-path para apontar para a pasta ObjectX correta."
+        )
+
+    height = world_path / "TerrainHeight.OZB"
+    if not height.exists():
+        height = world_path / "TerrainHeightNew.OZB"
+    if not height.exists():
+        raise FileNotFoundError("Arquivo de altura TerrainHeight.OZB ou TerrainHeightNew.OZB não encontrado.")
+
+    return attributes, mapping, objects, height
+
+
+def load_world_data(
+    world_path: Path,
+    *,
+    map_id: Optional[int],
+    object_path: Optional[Path],
+    extended_height: bool,
+    height_scale: Optional[float],
+    enum_path: Optional[Path],
+) -> TerrainLoadResult:
+    if not world_path.is_dir():
+        raise FileNotFoundError(f"Diretório inválido: {world_path}")
+
+    attributes_path, mapping_path, objects_path, height_path = resolve_files(
+        world_path, map_id, object_path=object_path
+    )
+
+    enum_candidate = enum_path
+    if enum_candidate is None:
+        if DEFAULT_ENUM_PATH.exists():
+            enum_candidate = DEFAULT_ENUM_PATH
+    model_names: Mapping[int, str] = {}
+    if enum_candidate and enum_candidate.exists():
+        model_names = load_model_names(str(enum_candidate.resolve()))
+
+    attr_map_id, attributes = open_terrain_attribute(attributes_path)
+    mapping_map_id, layer1, layer2, alpha = open_terrain_mapping(mapping_path)
+    obj_map_id, objects = open_objects_enc(objects_path, model_names)
+    height = load_height_file(
+        height_path,
+        extended=extended_height or height_path.name.endswith("New.OZB"),
+        scale_override=height_scale,
+    )
+
+    terrain = TerrainData(
+        height=height,
+        mapping_layer1=layer1,
+        mapping_layer2=layer2,
+        mapping_alpha=alpha,
+        attributes=attributes,
+    )
+
+    resolved_map_id: Optional[int] = None
+    id_sources = [
+        ("parâmetro", map_id),
+        ("EncTerrain.map", mapping_map_id),
+        ("EncTerrain.att", attr_map_id),
+        ("EncTerrain.obj", obj_map_id),
+    ]
+    for label, value in id_sources:
+        if value is None:
+            continue
+        if resolved_map_id is None:
+            resolved_map_id = value
+        elif value != resolved_map_id:
+            raise ValueError(
+                f"ID do mapa inconsistente: {label} aponta para {value},"
+                f" mas o esperado é {resolved_map_id}."
+            )
+
+    if resolved_map_id is None:
+        resolved_map_id = 0
+
+    return TerrainLoadResult(
+        world_path=world_path,
+        data=terrain,
+        objects=objects,
+        map_id=resolved_map_id,
+        map_id_attribute=attr_map_id,
+        map_id_mapping=mapping_map_id,
+        map_id_objects=obj_map_id,
+        model_names=model_names,
+    )
+
+
+def object_summary(result: TerrainLoadResult, *, limit: int = 8) -> List[Tuple[int, int, Optional[str]]]:
+    counter = Counter(obj.type_id for obj in result.objects)
+    summary: List[Tuple[int, int, Optional[str]]] = []
+    for type_id, count in counter.most_common(limit):
+        summary.append((type_id, count, result.model_names.get(type_id)))
+    return summary
+
+
+def format_summary_line(result: TerrainLoadResult, *, limit: int = 5) -> str:
+    pieces = [
+        f"Mapa {result.map_id}",
+        f"{len(result.objects)} objetos",
+    ]
+    highlights = []
+    for type_id, count, name in object_summary(result, limit=limit):
+        label = name.replace("MODEL_", "") if name else "ID"
+        highlights.append(f"{count}× {label} ({type_id})")
+    if highlights:
+        pieces.append("principais: " + ", ".join(highlights))
+    return " | ".join(pieces)
+
+
+def print_summary(result: TerrainLoadResult, *, limit: int = 8) -> None:
+    print(format_summary_line(result, limit=limit))
+
+
+def run_viewer(
+    world_path: Path,
+    *,
+    map_id: Optional[int],
+    object_path: Optional[Path],
+    extended_height: bool,
+    height_scale: Optional[float],
+    output: Optional[Path],
+    show: bool,
+    max_objects: Optional[int],
+    enum_path: Optional[Path] = None,
+    log_summary: bool = True,
+) -> TerrainLoadResult:
+    result = load_world_data(
+        world_path,
+        map_id=map_id,
+        object_path=object_path,
+        extended_height=extended_height,
+        height_scale=height_scale,
+        enum_path=enum_path,
+    )
+
+    render_scene(
+        result.data,
+        result.objects,
+        output=output,
+        show=show,
+        max_objects=max_objects,
+        title=f"{world_path.name} (mapa {result.map_id}) — {len(result.objects)} objetos",
+    )
+
+    if log_summary:
+        print_summary(result)
+    return result
+
+
+def list_world_directories(data_path: Path) -> List[Path]:
+    worlds: List[Path] = []
+    if not data_path.is_dir():
+        return worlds
+    for child in sorted(data_path.iterdir()):
+        if not child.is_dir():
+            continue
+        lower = child.name.lower()
+        if lower.startswith("world") and find_first("EncTerrain*.map", child):
+            worlds.append(child)
+            continue
+        if find_first("EncTerrain*.map", child):
+            worlds.append(child)
+    return worlds
+
+
+def _safe_int(value: str) -> Optional[int]:
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+class TerrainViewerGUI:
+    def __init__(
+        self,
+        *,
+        initial_data_dir: Optional[Path] = None,
+        enum_path: Optional[Path] = None,
+    ):
+        self.root = tk.Tk()
+        self.root.title("Visualizador de Terreno")
+
+        self.data_dir_var = tk.StringVar()
+        self.world_var = tk.StringVar()
+        self.map_id_var = tk.StringVar()
+        self.height_scale_var = tk.StringVar()
+        self.max_objects_var = tk.StringVar()
+        self.extended_height_var = tk.BooleanVar()
+
+        self.object_dir_var = tk.StringVar()
+        self.status_var = tk.StringVar()
+
+        self.world_options: List[Path] = []
+        self.enum_path = None
+        if enum_path and enum_path.exists():
+            self.enum_path = enum_path
+        elif DEFAULT_ENUM_PATH.exists():
+            self.enum_path = DEFAULT_ENUM_PATH
+
+        if initial_data_dir and initial_data_dir.is_dir():
+            self.data_dir_var.set(str(initial_data_dir))
+            self._populate_worlds(initial_data_dir)
+
+        self._build_layout()
+
+    def _build_layout(self) -> None:
+        padding = {"padx": 8, "pady": 4}
+
+        data_frame = tk.LabelFrame(self.root, text="Diretórios")
+        data_frame.grid(row=0, column=0, sticky="ew", **padding)
+
+        tk.Label(data_frame, text="Pasta Data:").grid(row=0, column=0, sticky="w")
+        data_entry = tk.Entry(data_frame, textvariable=self.data_dir_var, width=50)
+        data_entry.grid(row=0, column=1, sticky="ew", padx=(4, 4))
+        tk.Button(data_frame, text="Escolher...", command=self.choose_data_dir).grid(row=0, column=2)
+
+        tk.Label(data_frame, text="Pasta World:").grid(row=1, column=0, sticky="w")
+        self.world_menu = tk.OptionMenu(data_frame, self.world_var, "")
+        self.world_menu.config(width=45)
+        self.world_menu.grid(row=1, column=1, sticky="ew", padx=(4, 4))
+        tk.Button(data_frame, text="Atualizar", command=self.refresh_worlds).grid(row=1, column=2)
+
+        tk.Label(data_frame, text="Pasta Object (opcional):").grid(row=2, column=0, sticky="w")
+        object_entry = tk.Entry(data_frame, textvariable=self.object_dir_var, width=50)
+        object_entry.grid(row=2, column=1, sticky="ew", padx=(4, 4))
+        tk.Button(data_frame, text="Escolher...", command=self.choose_object_dir).grid(row=2, column=2)
+
+        data_frame.columnconfigure(1, weight=1)
+
+        options_frame = tk.LabelFrame(self.root, text="Opções")
+        options_frame.grid(row=1, column=0, sticky="ew", **padding)
+
+        tk.Label(options_frame, text="Map ID:").grid(row=0, column=0, sticky="w")
+        tk.Entry(options_frame, textvariable=self.map_id_var, width=10).grid(row=0, column=1, sticky="w")
+
+        tk.Label(options_frame, text="Height scale:").grid(row=0, column=2, sticky="w")
+        tk.Entry(options_frame, textvariable=self.height_scale_var, width=10).grid(row=0, column=3, sticky="w")
+
+        tk.Label(options_frame, text="Max objects:").grid(row=1, column=0, sticky="w")
+        tk.Entry(options_frame, textvariable=self.max_objects_var, width=10).grid(row=1, column=1, sticky="w")
+
+        tk.Checkbutton(
+            options_frame,
+            text="Forçar TerrainHeightNew",
+            variable=self.extended_height_var,
+        ).grid(row=1, column=2, columnspan=2, sticky="w")
+
+        buttons_frame = tk.Frame(self.root)
+        buttons_frame.grid(row=2, column=0, sticky="e", **padding)
+
+        tk.Button(buttons_frame, text="Visualizar", command=self.visualize).grid(row=0, column=0, padx=4)
+        tk.Button(buttons_frame, text="Salvar PNG", command=self.save_png).grid(row=0, column=1, padx=4)
+        tk.Button(buttons_frame, text="Sair", command=self.root.quit).grid(row=0, column=2, padx=4)
+
+        status_label = tk.Label(self.root, textvariable=self.status_var, anchor="w")
+        status_label.grid(row=3, column=0, sticky="ew", padx=8, pady=(0, 8))
+
+        self.root.columnconfigure(0, weight=1)
+
+    def choose_data_dir(self) -> None:
+        path = filedialog.askdirectory(title="Selecione a pasta Data")
+        if path:
+            self.data_dir_var.set(path)
+            self._populate_worlds(Path(path))
+
+    def choose_object_dir(self) -> None:
+        path = filedialog.askdirectory(title="Selecione a pasta ObjectX")
+        if path:
+            self.object_dir_var.set(path)
+
+    def refresh_worlds(self) -> None:
+        data_path = Path(self.data_dir_var.get())
+        if not data_path.exists():
+            messagebox.showerror("Erro", "Selecione uma pasta Data válida.")
+            return
+        self._populate_worlds(data_path)
+
+    def _populate_worlds(self, data_path: Path) -> None:
+        self.world_options = list_world_directories(data_path)
+        menu = self.world_menu["menu"]
+        menu.delete(0, "end")
+        if not self.world_options:
+            self.world_var.set("")
+            return
+        for world in self.world_options:
+            menu.add_command(label=world.name, command=lambda w=world: self._select_world(w))
+        self._select_world(self.world_options[0])
+
+    def _select_world(self, world_path: Path) -> None:
+        self.world_var.set(world_path.name)
+        inferred = infer_map_id(world_path)
+        if inferred is not None:
+            self.map_id_var.set(str(inferred))
+
+    def _current_world_path(self) -> Optional[Path]:
+        selected = self.world_var.get()
+        if not selected:
+            return None
+        data_path = Path(self.data_dir_var.get())
+        return data_path / selected
+
+    def visualize(self) -> None:
+        try:
+            self._run(show=True)
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Erro", str(exc))
+
+    def save_png(self) -> None:
+        output_path = filedialog.asksaveasfilename(
+            title="Salvar visualização",
+            defaultextension=".png",
+            filetypes=[("PNG", "*.png")],
+        )
+        if not output_path:
+            return
+        try:
+            self._run(show=False, output=Path(output_path))
+            messagebox.showinfo("Sucesso", f"PNG salvo em {output_path}")
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Erro", str(exc))
+
+    def _run(self, *, show: bool, output: Optional[Path] = None) -> None:
+        world_path = self._current_world_path()
+        if world_path is None:
+            raise ValueError("Selecione uma pasta World válida.")
+        map_id = _safe_int(self.map_id_var.get())
+        height_scale = self._parse_float(self.height_scale_var.get())
+        max_objects = _safe_int(self.max_objects_var.get())
+        object_dir = Path(self.object_dir_var.get()) if self.object_dir_var.get() else None
+        result = run_viewer(
+            world_path,
+            map_id=map_id,
+            object_path=object_dir,
+            extended_height=self.extended_height_var.get(),
+            height_scale=height_scale,
+            output=output,
+            show=show,
+            max_objects=max_objects,
+            enum_path=self.enum_path,
+            log_summary=False,
+        )
+        self.map_id_var.set(str(result.map_id))
+        self.status_var.set(format_summary_line(result))
+
+    @staticmethod
+    def _parse_float(value: str) -> Optional[float]:
+        value = value.strip()
+        if not value:
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            raise ValueError("Height scale inválido.")
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Visualizador de terreno legado")
+    parser.add_argument("world_path", nargs="?", type=Path, help="Pasta Data/WorldX com os arquivos do mapa")
+    parser.add_argument("--map-id", type=int, dest="map_id", help="ID numérico usado nos arquivos EncTerrain")
+    parser.add_argument(
+        "--object-path",
+        type=Path,
+        dest="object_path",
+        help="Diretório ObjectX a ser usado para carregar EncTerrainXX.obj",
+    )
+    parser.add_argument(
+        "--data-root",
+        type=Path,
+        dest="data_root",
+        help="Pasta Data contendo subpastas WorldX/ObjectX (usada para a interface gráfica).",
+    )
+    parser.add_argument("--extended-height", action="store_true", help="Força o parse do formato estendido de altura")
+    parser.add_argument("--output", type=Path, help="Arquivo de saída (PNG). Se omitido, não salva.")
+    parser.add_argument("--no-show", action="store_true", help="Não abrir a janela interativa do Matplotlib")
+    parser.add_argument("--max-objects", type=int, help="Limita quantidade de objetos renderizados")
+    parser.add_argument(
+        "--height-scale",
+        type=float,
+        help="Fator de escala aplicado às alturas no formato clássico (padrão 1.5).",
+    )
+    parser.add_argument("--gui", action="store_true", help="Abre a interface gráfica de seleção de mapas.")
+    parser.add_argument(
+        "--enum-path",
+        type=Path,
+        dest="enum_path",
+        help="Arquivo _enum.h para nomear tipos de objeto (padrão: source/_enum.h).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.gui or args.world_path is None:
+        app = TerrainViewerGUI(initial_data_dir=args.data_root, enum_path=args.enum_path)
+        app.run()
+        return
+
+    run_viewer(
+        args.world_path,
+        map_id=args.map_id,
+        object_path=args.object_path,
+        extended_height=args.extended_height,
+        height_scale=args.height_scale,
+        output=args.output,
+        show=not args.no_show,
+        max_objects=args.max_objects,
+        enum_path=args.enum_path,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- parse `_enum.h` to resolve terrain object names and reuse the data when decoding EncTerrainXX.obj
- surface per-map object statistics in both CLI output and the GUI status bar, including map-id validation and colored markers
- document the new behaviour and expose an `--enum-path` option for overriding the source of model names

## Testing
- python -m compileall tools/terrain_viewer/terrain_viewer.py

------
https://chatgpt.com/codex/tasks/task_e_68e4152031888332b0c500b43e17754d