### PR TITLE
Enable interactive object editing in terrain viewer

### DIFF
--- a/tools/terrain_viewer/README.md
+++ b/tools/terrain_viewer/README.md
@@ -59,6 +59,9 @@ do zero e usa apenas ações comuns no Windows:
      correspondente quando encontrada.
    - Pressione **Visualizar** para carregar o mapa; a janela exibirá o terreno
      e uma lista dos objetos encontrados.
+   - Marque **Permitir mover objetos** para habilitar a edição direta na janela
+     do Matplotlib. Selecione um ponto com o mouse e use as setas para mover a
+     instância (Shift acelera o passo, `[` e `]` ajustam a distância percorrida).
    - Para gerar relatórios rápidos, utilize os botões **Resumo** (exibe
      estatísticas detalhadas) ou **Exportar objetos** (salva um CSV com a lista
      completa de instâncias do mapa).
@@ -137,6 +140,8 @@ em nomes legíveis.
   com milhares de instâncias).
 - `--object-path`: aponta diretamente para a pasta `ObjectX` quando os objetos
   não estão junto do `WorldX`.
+- `--edit-objects`: habilita a movimentação das instâncias exibidas (janela
+  interativa obrigatória, remova `--no-show`).
 - `--no-show`: evita abrir a janela interativa do Matplotlib.
 - `--output`: caminho do arquivo PNG de saída.
 - `--height-scale`: ajusta o fator aplicado ao formato clássico de altura (1.5


### PR DESCRIPTION
## Summary
- add an interactive object editor that lets the matplotlib scatter plot respond to clicks and keyboard movement
- expose the editor through a new CLI flag and GUI checkbox while documenting the controls in the README

## Testing
- python -m compileall tools/terrain_viewer/terrain_viewer.py

------
https://chatgpt.com/codex/tasks/task_e_68e433b632f083328f164d01d3db5f46