### PR TITLE
Add 2D mode and persistence features to terrain viewer

### DIFF
--- a/tools/terrain_viewer/README.md
+++ b/tools/terrain_viewer/README.md
@@ -59,9 +59,20 @@ do zero e usa apenas ações comuns no Windows:
      correspondente quando encontrada.
    - Pressione **Visualizar** para carregar o mapa; a janela exibirá o terreno
      e uma lista dos objetos encontrados.
+   - Ajuste **Modo de visualização** para alternar entre a cena 3D padrão e a
+     nova visão 2D (heatmap) — útil para posicionar instâncias com precisão.
+   - Troque o **Overlay** para colorir o terreno pelas texturas, altura ou
+     atributos. Os campos **Mostrar apenas** e **Ocultar** filtram os objetos
+     renderizados por ID ou texto livre.
+   - Marque **Permitir mover objetos** para habilitar a edição direta na janela
+     do Matplotlib. Selecione um ponto com o mouse e use as setas para mover a
+     instância (Shift acelera o passo, `[` e `]` ajustam a distância percorrida).
+     Após fechar a janela, use **Salvar EncTerrain** para gerar um novo
+     `EncTerrainXX.obj` com as posições atualizadas.
    - Para gerar relatórios rápidos, utilize os botões **Resumo** (exibe
-     estatísticas detalhadas) ou **Exportar objetos** (salva um CSV com a lista
-     completa de instâncias do mapa).
+     estatísticas detalhadas), **Exportar objetos** (salva um CSV com a lista
+     filtrada), **Exportar JSON** (gera um arquivo estruturado para scripts) ou
+     **Salvar EncTerrain** (persiste as edições realizadas).
 
 > Dica: Se você quiser apenas gerar uma imagem, clique em **Salvar PNG** e
 > escolha onde guardar o arquivo. O processo leva alguns segundos em mapas
@@ -89,16 +100,19 @@ permite:
 1. Escolher a pasta `Data` por meio de um seletor de diretórios.
 2. Selecionar qual `WorldX` carregar usando um drop-down preenchido
    automaticamente com base na pasta escolhida.
-3. Ajustar opções como `Map ID`, escala de altura, limite de objetos e, se
-   necessário, apontar explicitamente para uma pasta `ObjectX`.
+3. Ajustar opções como `Map ID`, escala de altura, limite de objetos, modo de
+   visualização (3D/2D), overlay (texturas/altura/atributos) e filtros para
+   mostrar ou ocultar tipos específicos. Também é possível apontar
+   explicitamente para uma pasta `ObjectX`.
 
 Ao clicar em **Visualizar**, o terreno e os objetos são carregados e exibidos.
 O rodapé da janela mostra um resumo com a contagem total de objetos e os tipos
 mais frequentes (com nomes extraídos do `_enum.h` do cliente). Também é
 possível gerar uma imagem PNG diretamente pelo botão **Salvar PNG**. Caso
-precise analisar os dados, use **Resumo** para visualizar estatísticas (altura,
-atributos e texturas) e **Exportar objetos** para salvar um CSV com todas as
-instâncias posicionadas no mapa.
+precise analisar os dados, use **Resumo** para visualizar estatísticas
+(altura/atributos/texturas), **Exportar objetos** ou **Exportar JSON** para
+obter a lista filtrada em CSV/JSON, e **Salvar EncTerrain** para persistir as
+edições feitas no editor interativo.
 
 ### Linha de comando
 
@@ -120,9 +134,11 @@ em nomes legíveis.
 
 ### Exportando e inspecionando dados
 
-- `--export-objects caminho.csv`: grava um CSV com todos os objetos, incluindo
-  posição, ângulos, escala e as coordenadas em tiles. É útil para importar a
-  lista em ferramentas externas ou planilhas.
+- `--export-objects caminho.csv`: grava um CSV com os objetos visíveis na
+  visualização atual, incluindo posição, ângulos, escala e as coordenadas em
+  tiles. É útil para importar a lista em ferramentas externas ou planilhas.
+- `--export-json caminho.json`: exporta o mesmo conjunto filtrado em formato
+  JSON, junto com estatísticas básicas de altura e o histograma de atributos.
 - `--detailed-summary`: exibe estatísticas adicionais diretamente no terminal,
   como altura mínima/máxima, quantidade de texturas utilizadas e os atributos
   mais comuns.
@@ -137,6 +153,16 @@ em nomes legíveis.
   com milhares de instâncias).
 - `--object-path`: aponta diretamente para a pasta `ObjectX` quando os objetos
   não estão junto do `WorldX`.
+- `--view-mode`: alterna entre o modo 3D tradicional e a visualização 2D
+  (heatmap) com sobreposição plana.
+- `--overlay`: define o mapa de cores do terreno (texturas, altura ou
+  atributos).
+- `--filter` / `--exclude`: incluem ou ocultam objetos cujo ID ou nome contenha
+  o texto informado (argumento pode ser repetido).
+- `--save-objects`: grava um novo arquivo `EncTerrainXX.obj` criptografado com
+  as posições atuais (ideal após mover objetos na interface interativa).
+- `--edit-objects`: habilita a movimentação das instâncias exibidas (janela
+  interativa obrigatória, remova `--no-show`).
 - `--no-show`: evita abrir a janela interativa do Matplotlib.
 - `--output`: caminho do arquivo PNG de saída.
 - `--height-scale`: ajusta o fator aplicado ao formato clássico de altura (1.5
@@ -157,10 +183,33 @@ em nomes legíveis.
   se você estiver usando uma versão antiga basta marcar a opção **Forçar
   TerrainHeightNew** na interface (ou executar com `--extended-height`).
 
+## Possíveis melhorias
+
+Algumas ideias de evolução que podem deixar o visualizador mais prático no dia
+a dia:
+
+- **Histórico de edições com desfazer/refazer.** Registrar cada movimento e
+  permitir desfazer etapas facilitaria experimentos mais longos sem medo de
+  perder o progresso.
+- **Snapping inteligente.** Adicionar alinhamento por grade, altura ou objetos
+  vizinhos ajudaria a posicionar modelos complexos com mais precisão.
+- **Edição de atributos e texturas.** Estender o editor para permitir ajustes
+  diretos em `TerrainAttribute` e nas camadas de textura, atualizando os
+  arquivos `.att/.map` no mesmo fluxo.
+- **Comparação entre revisões.** Uma visualização lado a lado (ou modo diff)
+  destacaria objetos adicionados/removidos entre duas pastas `WorldX`.
+- **Renderização com recursos do jogo.** Carregar as texturas reais e aplicar
+  shaders/iluminação aproximada deixaria a prévia ainda mais próxima do cliente.
+
 ## Exemplo
 
 ```bash
 python terrain_viewer.py /caminho/para/Data/World7 --max-objects 500 --output world7.png --no-show
+```
+
+```bash
+python terrain_viewer.py /caminho/para/Data/World7 --view-mode 2d --overlay height \
+    --filter MODEL_TREE --export-json world7_trees.json --no-show
 ```
 
 O script decodifica os arquivos criptografados usando as mesmas rotinas inline

--- a/tools/terrain_viewer/terrain_viewer.py
+++ b/tools/terrain_viewer/terrain_viewer.py
@@ -10,17 +10,22 @@ import argparse
 import ast
 import csv
 import functools
+import json
 import math
 import re
 import struct
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
 import tkinter as tk
+from matplotlib.axes import Axes
+from matplotlib.backend_bases import KeyEvent, PickEvent
+from matplotlib.figure import Figure
+from mpl_toolkits.mplot3d.art3d import Path3DCollection
 from tkinter import filedialog, messagebox
 
 TERRAIN_SIZE = 256
@@ -186,6 +191,9 @@ class TerrainLoadResult:
     map_id_mapping: int
     map_id_objects: int
     model_names: Mapping[int, str]
+    objects_path: Path
+    objects_version: int
+    all_objects: List[TerrainObject]
 
 
 def map_file_decrypt(data: bytes) -> bytes:
@@ -198,6 +206,20 @@ def map_file_decrypt(data: bytes) -> bytes:
         decrypted = ((byte ^ xor_key[idx % len(xor_key)]) - w_map_key) & 0xFF
         out[idx] = decrypted
         w_map_key = (byte + 0x3D) & 0xFF
+    return bytes(out)
+
+
+def map_file_encrypt(data: bytes) -> bytes:
+    """Inverte a rotina inline para gerar novos arquivos EncTerrain."""
+
+    xor_key = MAP_XOR_KEY
+    w_map_key = 0x5E
+    out = bytearray(len(data))
+    for idx, byte in enumerate(data):
+        value = (byte + w_map_key) & 0xFF
+        encrypted = value ^ xor_key[idx % len(xor_key)]
+        out[idx] = encrypted
+        w_map_key = (encrypted + 0x3D) & 0xFF
     return bytes(out)
 
 
@@ -294,10 +316,13 @@ def load_height_file(path: Path, *, extended: bool = False, scale_override: Opti
     return heights.reshape((TERRAIN_SIZE, TERRAIN_SIZE))
 
 
-def open_objects_enc(path: Path, model_names: Mapping[int, str]) -> Tuple[int, List[TerrainObject]]:
+def open_objects_enc(
+    path: Path, model_names: Mapping[int, str]
+) -> Tuple[int, int, List[TerrainObject]]:
     raw = _read_file(path)
     decrypted = map_file_decrypt(raw)
     ptr = 0
+    version = decrypted[ptr]
     ptr += 1  # versão
     map_id = decrypted[ptr]
     ptr += 1  # número do mapa
@@ -322,7 +347,7 @@ def open_objects_enc(path: Path, model_names: Mapping[int, str]) -> Tuple[int, L
                 type_name=model_names.get(type_id),
             )
         )
-    return int(map_id), objects
+    return int(map_id), int(version), objects
 
 
 def bilinear_height(height: np.ndarray, x: float, y: float) -> float:
@@ -337,57 +362,159 @@ def bilinear_height(height: np.ndarray, x: float, y: float) -> float:
     return h1 * (1 - xd) + h2 * xd
 
 
+def _split_filter_values(values: Optional[Sequence[str]]) -> List[str]:
+    tokens: List[str] = []
+    if not values:
+        return tokens
+    for value in values:
+        if value is None:
+            continue
+        for piece in re.split(r"[;,]", value):
+            piece = piece.strip()
+            if piece:
+                tokens.append(piece)
+    return tokens
+
+
+def _object_matches(obj: TerrainObject, tokens: Sequence[str]) -> bool:
+    if not tokens:
+        return False
+    type_name = (obj.type_name or "").lower()
+    simplified = type_name.replace("model_", "")
+    for token in tokens:
+        lowered = token.lower()
+        if token.isdigit() and int(token) == obj.type_id:
+            return True
+        if lowered in type_name or lowered in simplified:
+            return True
+    return False
+
+
+def apply_object_filters(
+    objects: Sequence[TerrainObject],
+    include_tokens: Sequence[str],
+    exclude_tokens: Sequence[str],
+) -> List[TerrainObject]:
+    filtered: List[TerrainObject] = []
+    for obj in objects:
+        if exclude_tokens and _object_matches(obj, exclude_tokens):
+            continue
+        if include_tokens:
+            if _object_matches(obj, include_tokens):
+                filtered.append(obj)
+        else:
+            filtered.append(obj)
+    return filtered
+
+
+def _normalize_for_colormap(matrix: np.ndarray) -> np.ndarray:
+    matrix = matrix.astype(np.float32)
+    min_val = float(np.min(matrix))
+    max_val = float(np.max(matrix))
+    if math.isclose(max_val, min_val):
+        return np.zeros_like(matrix, dtype=np.float32)
+    return (matrix - min_val) / (max_val - min_val)
+
+
+def _overlay_matrix(data: TerrainData, overlay: str) -> Tuple[np.ndarray, str]:
+    if overlay == "attributes":
+        return data.attributes.astype(np.float32), "tab20"
+    if overlay == "height":
+        return data.height.astype(np.float32), "viridis"
+    return data.mapping_layer1.astype(np.float32), "terrain"
+
+
 def render_scene(
     data: TerrainData,
     objects: Sequence[TerrainObject],
     *,
     output: Optional[Path],
     show: bool,
-    max_objects: Optional[int],
     title: Optional[str] = None,
+    enable_object_edit: bool = False,
+    view_mode: str = "3d",
+    overlay: str = "textures",
 ) -> None:
-    x = np.arange(TERRAIN_SIZE)
-    y = np.arange(TERRAIN_SIZE)
-    xx, yy = np.meshgrid(x, y)
     heights = data.height
+    matrix, cmap_name = _overlay_matrix(data, overlay)
 
-    fig = plt.figure(figsize=(10, 7))
-    ax = fig.add_subplot(111, projection="3d")
+    if view_mode == "2d":
+        fig, ax = plt.subplots(figsize=(9, 8))
+        image = ax.imshow(matrix, origin="lower", cmap=cmap_name)
+        cbar = fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
+        cbar.ax.set_ylabel("Overlay")
+        if objects:
+            ox = np.array([obj.tile_position[0] for obj in objects])
+            oy = np.array([obj.tile_position[1] for obj in objects])
+            ax.scatter(ox, oy, c="white", s=10, edgecolors="black", linewidths=0.2)
+        ax.set_xlim(0, TERRAIN_SIZE - 1)
+        ax.set_ylim(0, TERRAIN_SIZE - 1)
+        ax.set_xlabel("X (tiles)")
+        ax.set_ylabel("Y (tiles)")
+        ax.set_title(title or "Visualização 2D do terreno")
+        ax.set_aspect("equal", adjustable="box")
+        fig.tight_layout()
+    else:
+        x = np.arange(TERRAIN_SIZE)
+        y = np.arange(TERRAIN_SIZE)
+        xx, yy = np.meshgrid(x, y)
+        fig = plt.figure(figsize=(10, 7))
+        ax = fig.add_subplot(111, projection="3d")
 
-    cmap = plt.get_cmap("terrain")
-    face_colors = cmap((data.mapping_layer1.astype(np.float32) / 255.0))
+        cmap = plt.get_cmap(cmap_name)
+        face_colors = cmap(_normalize_for_colormap(matrix))
 
-    ax.plot_surface(
-        xx,
-        yy,
-        heights,
-        rstride=2,
-        cstride=2,
-        facecolors=face_colors,
-        linewidth=0,
-        antialiased=False,
-        shade=False,
-    )
+        ax.plot_surface(
+            xx,
+            yy,
+            heights,
+            rstride=2,
+            cstride=2,
+            facecolors=face_colors,
+            linewidth=0,
+            antialiased=False,
+            shade=False,
+        )
 
-    if objects:
-        used_objects = objects[:max_objects] if max_objects is not None else objects
-        ox = np.array([obj.tile_position[0] for obj in used_objects])
-        oy = np.array([obj.tile_position[1] for obj in used_objects])
-        oz = np.array([bilinear_height(heights, x, y) for x, y in zip(ox, oy)])
-        type_ids = np.array([obj.type_id for obj in used_objects], dtype=float)
-        if type_ids.size > 0 and type_ids.ptp() > 0:
-            colors = (type_ids - type_ids.min()) / type_ids.ptp()
-        else:
-            colors = np.zeros_like(type_ids)
-        ax.scatter(ox, oy, oz + 50.0, c=colors, cmap="tab20", s=10, depthshade=False)
+        scatter: Optional[Path3DCollection] = None
+        if objects:
+            ox = np.array([obj.tile_position[0] for obj in objects])
+            oy = np.array([obj.tile_position[1] for obj in objects])
+            oz = np.array([bilinear_height(heights, x, y) for x, y in zip(ox, oy)])
+            type_ids = np.array([obj.type_id for obj in objects], dtype=float)
+            if type_ids.size > 0 and type_ids.ptp() > 0:
+                colors = (type_ids - type_ids.min()) / type_ids.ptp()
+            else:
+                colors = np.zeros_like(type_ids)
+            scatter = ax.scatter(
+                ox,
+                oy,
+                oz + 50.0,
+                c=colors,
+                cmap="tab20",
+                s=10,
+                depthshade=False,
+                picker=True,
+                pickradius=5,
+            )
 
-    ax.set_xlabel("X (tiles)")
-    ax.set_ylabel("Y (tiles)")
-    ax.set_zlabel("Altura")
-    ax.view_init(elev=60, azim=45)
-    if title:
-        ax.set_title(title)
-    plt.tight_layout()
+            if enable_object_edit and show:
+                editor = ObjectEditor(
+                    fig,
+                    ax,
+                    scatter,
+                    objects,
+                    data.height,
+                )
+                fig._terrain_object_editor = editor  # type: ignore[attr-defined]
+
+        ax.set_xlabel("X (tiles)")
+        ax.set_ylabel("Y (tiles)")
+        ax.set_zlabel("Altura")
+        ax.view_init(elev=60, azim=45)
+        if title:
+            ax.set_title(title)
+        plt.tight_layout()
 
     if output:
         fig.savefig(output)
@@ -397,6 +524,169 @@ def render_scene(
         plt.show()
     else:
         plt.close(fig)
+
+
+class ObjectEditor:
+    """Permite mover objetos renderizados usando eventos do Matplotlib."""
+
+    def __init__(
+        self,
+        fig: Figure,
+        ax: Axes,
+        scatter: Path3DCollection,
+        objects: Sequence[TerrainObject],
+        heights: np.ndarray,
+    ) -> None:
+        self.fig = fig
+        self.ax = ax
+        self.scatter = scatter
+        self.objects = list(objects)
+        self.heights = heights
+        self.selected_index: Optional[int] = None
+        self.step_tiles = 0.5
+
+        self.info_label = ax.text2D(
+            0.02,
+            0.02,
+            self._format_info_text(),
+            transform=ax.transAxes,
+            color="yellow",
+            fontsize=9,
+            ha="left",
+            va="bottom",
+            bbox={"facecolor": "black", "alpha": 0.6, "pad": 4},
+        )
+        self.selection_label = ax.text2D(
+            0.02,
+            0.94,
+            "",
+            transform=ax.transAxes,
+            color="cyan",
+            fontsize=10,
+            ha="left",
+            va="top",
+            bbox={"facecolor": "black", "alpha": 0.5, "pad": 4},
+        )
+        self.selection_label.set_visible(False)
+
+        canvas = fig.canvas
+        self.cid_pick = canvas.mpl_connect("pick_event", self.on_pick)
+        self.cid_key = canvas.mpl_connect("key_press_event", self.on_key_press)
+        self.cid_close = canvas.mpl_connect("close_event", self.on_close)
+
+        print(
+            "Edição habilitada: clique em um ponto para selecionar um objeto e use"
+            " as setas para mover. Shift acelera o passo. Use [ e ] para ajustar"
+            " o passo."
+        )
+
+    def _format_info_text(self) -> str:
+        return (
+            "Setas: mover objeto  |  Shift: x5  |  [: passo/2  |  ]: passo*2  "
+            f"| Passo atual: {self.step_tiles:.2f} tiles"
+        )
+
+    def on_pick(self, event: PickEvent) -> None:
+        if event.artist is not self.scatter:
+            return
+        indices = getattr(event, "ind", [])
+        if not indices:
+            return
+        index_array = np.atleast_1d(indices)
+        self.selected_index = int(index_array[0])
+        obj = self.objects[self.selected_index]
+        text = (
+            f"Selecionado #{self.selected_index} — ID {obj.type_id}"
+            f" ({obj.type_name or 'sem nome'})\n"
+            f"Tile: {obj.tile_position[0]:.2f}, {obj.tile_position[1]:.2f}"
+        )
+        self.selection_label.set_text(text)
+        self.selection_label.set_visible(True)
+        self.fig.canvas.draw_idle()
+
+    def on_key_press(self, event: KeyEvent) -> None:
+        if self.selected_index is None:
+            return
+        if not event.key:
+            return
+
+        parts = event.key.split("+")
+        key = parts[-1]
+        modifiers = set(parts[:-1])
+
+        if key == "escape":
+            self.selected_index = None
+            self.selection_label.set_visible(False)
+            self.fig.canvas.draw_idle()
+            return
+
+        if key == "]":
+            self.step_tiles = min(self.step_tiles * 2.0, 10.0)
+            self.info_label.set_text(self._format_info_text())
+            self.fig.canvas.draw_idle()
+            return
+
+        if key == "[":
+            self.step_tiles = max(self.step_tiles / 2.0, 0.03125)
+            self.info_label.set_text(self._format_info_text())
+            self.fig.canvas.draw_idle()
+            return
+
+        multiplier = 5.0 if "shift" in modifiers else 1.0
+        step = self.step_tiles * multiplier
+
+        delta_x = 0.0
+        delta_y = 0.0
+        if key == "up":
+            delta_y += step
+        elif key == "down":
+            delta_y -= step
+        elif key == "left":
+            delta_x -= step
+        elif key == "right":
+            delta_x += step
+        else:
+            return
+
+        self._move_selected(delta_x, delta_y)
+
+    def _move_selected(self, delta_x: float, delta_y: float) -> None:
+        if self.selected_index is None:
+            return
+        obj = self.objects[self.selected_index]
+        tile_x = obj.tile_position[0] + delta_x
+        tile_y = obj.tile_position[1] + delta_y
+        tile_x = float(np.clip(tile_x, 0.0, TERRAIN_SIZE - 1))
+        tile_y = float(np.clip(tile_y, 0.0, TERRAIN_SIZE - 1))
+        height = bilinear_height(self.heights, tile_x, tile_y)
+
+        obj.position = (
+            tile_x * TERRAIN_SCALE,
+            tile_y * TERRAIN_SCALE,
+            height,
+        )
+
+        ox, oy, oz = self.scatter._offsets3d
+        ox_arr = np.asarray(ox)
+        oy_arr = np.asarray(oy)
+        oz_arr = np.asarray(oz)
+        ox_arr[self.selected_index] = tile_x
+        oy_arr[self.selected_index] = tile_y
+        oz_arr[self.selected_index] = height + 50.0
+        self.scatter._offsets3d = (ox_arr, oy_arr, oz_arr)  # type: ignore[assignment]
+
+        self.selection_label.set_text(
+            f"Selecionado #{self.selected_index} — ID {obj.type_id}"
+            f" ({obj.type_name or 'sem nome'})\n"
+            f"Tile: {tile_x:.2f}, {tile_y:.2f}"
+        )
+        self.fig.canvas.draw_idle()
+
+    def on_close(self, _event: Optional[object]) -> None:
+        canvas = self.fig.canvas
+        canvas.mpl_disconnect(self.cid_pick)
+        canvas.mpl_disconnect(self.cid_key)
+        canvas.mpl_disconnect(self.cid_close)
 
 
 def find_first(pattern: str, directory: Path) -> Optional[Path]:
@@ -511,13 +801,14 @@ def load_world_data(
 
     attr_map_id, attributes = open_terrain_attribute(attributes_path)
     mapping_map_id, layer1, layer2, alpha = open_terrain_mapping(mapping_path)
-    obj_map_id, objects = open_objects_enc(objects_path, model_names)
+    obj_map_id, objects_version, objects = open_objects_enc(objects_path, model_names)
     height = load_height_file(
         height_path,
         extended=extended_height or height_path.name.endswith("New.OZB"),
         scale_override=height_scale,
     )
 
+    all_objects = list(objects)
     terrain = TerrainData(
         height=height,
         mapping_layer1=layer1,
@@ -556,6 +847,9 @@ def load_world_data(
         map_id_mapping=mapping_map_id,
         map_id_objects=obj_map_id,
         model_names=model_names,
+        objects_path=objects_path,
+        objects_version=objects_version,
+        all_objects=all_objects,
     )
 
 
@@ -570,8 +864,13 @@ def object_summary(result: TerrainLoadResult, *, limit: int = 8) -> List[Tuple[i
 def format_summary_line(result: TerrainLoadResult, *, limit: int = 5) -> str:
     pieces = [
         f"Mapa {result.map_id}",
-        f"{len(result.objects)} objetos",
     ]
+    visible = len(result.objects)
+    total = len(result.all_objects)
+    if visible != total:
+        pieces.append(f"{visible} de {total} objetos")
+    else:
+        pieces.append(f"{visible} objetos")
     highlights = []
     for type_id, count, name in object_summary(result, limit=limit):
         label = name.replace("MODEL_", "") if name else "ID"
@@ -651,7 +950,11 @@ def print_detailed_summary(
 
 
 def export_objects_csv(
-    result: TerrainLoadResult, destination: Path, *, include_tile_coords: bool = True
+    result: TerrainLoadResult,
+    destination: Path,
+    *,
+    include_tile_coords: bool = True,
+    objects: Optional[Sequence[TerrainObject]] = None,
 ) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     fieldnames = [
@@ -671,7 +974,7 @@ def export_objects_csv(
     with destination.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=fieldnames)
         writer.writeheader()
-        for obj in result.objects:
+        for obj in (objects if objects is not None else result.objects):
             row = {
                 "type_id": obj.type_id,
                 "type_name": obj.type_name or "",
@@ -688,6 +991,76 @@ def export_objects_csv(
                 row["tile_x"] = f"{tile_x:.3f}"
                 row["tile_y"] = f"{tile_y:.3f}"
             writer.writerow(row)
+
+
+def save_objects_file(
+    result: TerrainLoadResult, destination: Path, *, objects: Optional[Sequence[TerrainObject]] = None
+) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    used_objects = list(objects if objects is not None else result.all_objects)
+    payload = bytearray()
+    payload.append(result.objects_version & 0xFF)
+    payload.append(result.map_id_objects & 0xFF)
+    payload.extend(struct.pack("<h", len(used_objects)))
+    for obj in used_objects:
+        payload.extend(struct.pack("<h", obj.type_id))
+        payload.extend(struct.pack("<3f", *obj.position))
+        payload.extend(struct.pack("<3f", *obj.angles))
+        payload.extend(struct.pack("<f", obj.scale))
+    encrypted = map_file_encrypt(bytes(payload))
+    destination.write_bytes(encrypted)
+
+
+def export_result_json(
+    result: TerrainLoadResult,
+    destination: Path,
+    *,
+    objects: Optional[Sequence[TerrainObject]] = None,
+    include_height_stats: bool = True,
+) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    selected = list(objects if objects is not None else result.objects)
+    payload: Dict[str, object] = {
+        "map_id": result.map_id,
+        "world": result.world_path.name,
+        "object_count": len(selected),
+        "total_objects": len(result.all_objects),
+        "objects": [
+            {
+                "type_id": obj.type_id,
+                "type_name": obj.type_name,
+                "position": {
+                    "x": obj.position[0],
+                    "y": obj.position[1],
+                    "z": obj.position[2],
+                },
+                "angles": {
+                    "pitch": obj.angles[0],
+                    "yaw": obj.angles[1],
+                    "roll": obj.angles[2],
+                },
+                "scale": obj.scale,
+                "tile": {
+                    "x": obj.tile_position[0],
+                    "y": obj.tile_position[1],
+                },
+            }
+            for obj in selected
+        ],
+    }
+    if include_height_stats:
+        heights = result.data.height
+        payload["height"] = {
+            "min": float(np.min(heights)),
+            "max": float(np.max(heights)),
+            "mean": float(np.mean(heights)),
+        }
+    payload["attribute_histogram"] = [
+        {"value": int(value), "count": int(count)}
+        for value, count in Counter(result.data.attributes.flatten()).items()
+    ]
+    with destination.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
 
 
 
@@ -707,6 +1080,13 @@ def run_viewer(
     summary_limit: int = 8,
     render: bool = True,
     export_objects: Optional[Path] = None,
+    enable_object_edit: bool = False,
+    view_mode: str = "3d",
+    overlay: str = "textures",
+    include_filters: Optional[Sequence[str]] = None,
+    exclude_filters: Optional[Sequence[str]] = None,
+    export_json: Optional[Path] = None,
+    save_objects: Optional[Path] = None,
 ) -> TerrainLoadResult:
     result = load_world_data(
         world_path,
@@ -717,26 +1097,61 @@ def run_viewer(
         enum_path=enum_path,
     )
 
+    include_tokens = _split_filter_values(include_filters)
+    exclude_tokens = _split_filter_values(exclude_filters)
+    filtered_objects = apply_object_filters(result.all_objects, include_tokens, exclude_tokens)
+    display_objects = filtered_objects
+    truncated = False
+    if max_objects is not None and len(display_objects) > max_objects:
+        display_objects = display_objects[:max_objects]
+        truncated = True
+
+    display_result = replace(result, objects=list(display_objects))
+
+    if enable_object_edit and not show:
+        raise ValueError(
+            "A edição de objetos requer a janela interativa. Remova --no-show para usar esta opção."
+        )
+
+    if enable_object_edit and view_mode != "3d":
+        raise ValueError("A movimentação de objetos só está disponível no modo 3D.")
+
     if render:
         render_scene(
-            result.data,
-            result.objects,
+            display_result.data,
+            display_result.objects,
             output=output,
             show=show,
-            max_objects=max_objects,
-            title=f"{world_path.name} (mapa {result.map_id}) — {len(result.objects)} objetos",
+            title=f"{world_path.name} (mapa {display_result.map_id}) — {len(display_result.objects)} objetos",
+            enable_object_edit=enable_object_edit,
+            view_mode=view_mode,
+            overlay=overlay,
+        )
+
+    if truncated:
+        print(
+            "Aviso: limite de objetos aplicado. Apenas"
+            f" {len(display_result.objects)} de {len(filtered_objects)} objetos foram renderizados."
         )
 
     if export_objects is not None:
-        export_objects_csv(result, export_objects)
+        export_objects_csv(display_result, export_objects)
         print(f"Objetos exportados em {export_objects}")
+
+    if export_json is not None:
+        export_result_json(display_result, export_json)
+        print(f"Dados exportados em {export_json}")
+
+    if save_objects is not None:
+        save_objects_file(result, save_objects)
+        print(f"Arquivo EncTerrain salvo em {save_objects}")
 
     if log_summary:
         if detailed_summary:
-            print_detailed_summary(result, object_limit=summary_limit)
+            print_detailed_summary(display_result, object_limit=summary_limit)
         else:
-            print_summary(result, limit=summary_limit)
-    return result
+            print_summary(display_result, limit=summary_limit)
+    return display_result
 
 
 def list_world_directories(data_path: Path) -> List[Path]:
@@ -781,24 +1196,132 @@ class TerrainViewerGUI:
         self.height_scale_var = tk.StringVar()
         self.max_objects_var = tk.StringVar()
         self.extended_height_var = tk.BooleanVar()
+        self.edit_objects_var = tk.BooleanVar()
+        self.view_mode_var = tk.StringVar(value="3D")
+        self.overlay_var = tk.StringVar(value="Texturas")
+        self.include_filter_var = tk.StringVar()
+        self.exclude_filter_var = tk.StringVar()
 
         self.object_dir_var = tk.StringVar()
         self.status_var = tk.StringVar()
 
         self.world_options: List[Path] = []
         self.enum_path = None
+        self.view_mode_map = {"3D": "3d", "2D": "2d"}
+        self.overlay_map = {
+            "Texturas": "textures",
+            "Altura": "height",
+            "Atributos": "attributes",
+        }
         if enum_path and enum_path.exists():
             self.enum_path = enum_path
         elif DEFAULT_ENUM_PATH.exists():
             self.enum_path = DEFAULT_ENUM_PATH
 
         self.last_result: Optional[TerrainLoadResult] = None
+        self.last_params: Optional[Tuple[str, ...]] = None
 
         if initial_data_dir and initial_data_dir.is_dir():
             self.data_dir_var.set(str(initial_data_dir))
             self._populate_worlds(initial_data_dir)
 
         self._build_layout()
+
+    def _on_view_mode_change(self, *_: object) -> None:
+        mode = self.view_mode_map.get(self.view_mode_var.get(), "3d")
+        if mode != "3d":
+            if self.edit_objects_var.get():
+                self.edit_objects_var.set(False)
+            self.edit_checkbox.config(state="disabled")
+        else:
+            self.edit_checkbox.config(state="normal")
+
+    def _current_view_mode(self) -> str:
+        return self.view_mode_map.get(self.view_mode_var.get(), "3d")
+
+    def _current_overlay(self) -> str:
+        return self.overlay_map.get(self.overlay_var.get(), "textures")
+
+    def _current_filter_values(self) -> Tuple[Optional[str], Optional[str]]:
+        include = self.include_filter_var.get().strip()
+        exclude = self.exclude_filter_var.get().strip()
+        return (include or None, exclude or None)
+
+    def _compose_params(
+        self,
+        world_path: Path,
+        map_id: Optional[int],
+        height_scale: Optional[float],
+        max_objects: Optional[int],
+        object_dir: Optional[Path],
+        view_mode: str,
+        overlay: str,
+        include: Optional[str],
+        exclude: Optional[str],
+    ) -> Tuple[str, ...]:
+        return (
+            str(world_path.resolve()),
+            "" if map_id is None else str(map_id),
+            "" if height_scale is None else f"{height_scale:.6f}",
+            "" if max_objects is None else str(max_objects),
+            "" if object_dir is None else str(object_dir.resolve()),
+            "1" if self.extended_height_var.get() else "0",
+            view_mode,
+            overlay,
+            include or "",
+            exclude or "",
+        )
+
+    def _can_reuse_last(self, params: Tuple[str, ...]) -> bool:
+        return self.last_result is not None and self.last_params == params
+
+    def _gather_context(
+        self,
+    ) -> Tuple[
+        Path,
+        Optional[int],
+        Optional[float],
+        Optional[int],
+        Optional[Path],
+        str,
+        str,
+        Optional[str],
+        Optional[str],
+        Tuple[str, ...],
+    ]:
+        world_path = self._current_world_path()
+        if world_path is None:
+            raise ValueError("Selecione uma pasta World válida.")
+        map_id = _safe_int(self.map_id_var.get())
+        height_scale = self._parse_float(self.height_scale_var.get())
+        max_objects = _safe_int(self.max_objects_var.get())
+        object_dir = Path(self.object_dir_var.get()) if self.object_dir_var.get() else None
+        view_mode = self._current_view_mode()
+        overlay = self._current_overlay()
+        include, exclude = self._current_filter_values()
+        params = self._compose_params(
+            world_path,
+            map_id,
+            height_scale,
+            max_objects,
+            object_dir,
+            view_mode,
+            overlay,
+            include,
+            exclude,
+        )
+        return (
+            world_path,
+            map_id,
+            height_scale,
+            max_objects,
+            object_dir,
+            view_mode,
+            overlay,
+            include,
+            exclude,
+            params,
+        )
 
     def _build_layout(self) -> None:
         padding = {"padx": 8, "pady": 4}
@@ -842,19 +1365,53 @@ class TerrainViewerGUI:
             variable=self.extended_height_var,
         ).grid(row=1, column=2, columnspan=2, sticky="w")
 
+        tk.Label(options_frame, text="Modo de visualização:").grid(row=2, column=0, sticky="w")
+        tk.OptionMenu(
+            options_frame,
+            self.view_mode_var,
+            *self.view_mode_map.keys(),
+        ).grid(row=2, column=1, sticky="ew")
+
+        tk.Label(options_frame, text="Overlay:").grid(row=2, column=2, sticky="w")
+        tk.OptionMenu(
+            options_frame,
+            self.overlay_var,
+            *self.overlay_map.keys(),
+        ).grid(row=2, column=3, sticky="ew")
+
+        tk.Label(options_frame, text="Mostrar apenas (ID/nome):").grid(row=3, column=0, sticky="w")
+        tk.Entry(options_frame, textvariable=self.include_filter_var, width=20).grid(row=3, column=1, sticky="ew")
+
+        tk.Label(options_frame, text="Ocultar (ID/nome):").grid(row=3, column=2, sticky="w")
+        tk.Entry(options_frame, textvariable=self.exclude_filter_var, width=20).grid(row=3, column=3, sticky="ew")
+
+        self.edit_checkbox = tk.Checkbutton(
+            options_frame,
+            text="Permitir mover objetos (janela interativa)",
+            variable=self.edit_objects_var,
+        )
+        self.edit_checkbox.grid(row=4, column=0, columnspan=4, sticky="w")
+
+        options_frame.columnconfigure(1, weight=1)
+        options_frame.columnconfigure(3, weight=1)
+
         buttons_frame = tk.Frame(self.root)
         buttons_frame.grid(row=2, column=0, sticky="e", **padding)
 
         tk.Button(buttons_frame, text="Visualizar", command=self.visualize).grid(row=0, column=0, padx=4)
         tk.Button(buttons_frame, text="Salvar PNG", command=self.save_png).grid(row=0, column=1, padx=4)
         tk.Button(buttons_frame, text="Exportar objetos", command=self.export_objects).grid(row=0, column=2, padx=4)
-        tk.Button(buttons_frame, text="Resumo", command=self.show_summary).grid(row=0, column=3, padx=4)
-        tk.Button(buttons_frame, text="Sair", command=self.root.quit).grid(row=0, column=4, padx=4)
+        tk.Button(buttons_frame, text="Exportar JSON", command=self.export_json).grid(row=0, column=3, padx=4)
+        tk.Button(buttons_frame, text="Salvar EncTerrain", command=self.save_objects_dialog).grid(row=0, column=4, padx=4)
+        tk.Button(buttons_frame, text="Resumo", command=self.show_summary).grid(row=0, column=5, padx=4)
+        tk.Button(buttons_frame, text="Sair", command=self.root.quit).grid(row=0, column=6, padx=4)
 
         status_label = tk.Label(self.root, textvariable=self.status_var, anchor="w")
         status_label.grid(row=3, column=0, sticky="ew", padx=8, pady=(0, 8))
 
         self.root.columnconfigure(0, weight=1)
+        self.view_mode_var.trace_add("write", self._on_view_mode_change)
+        self._on_view_mode_change()
 
     def choose_data_dir(self) -> None:
         path = filedialog.askdirectory(title="Selecione a pasta Data")
@@ -910,6 +1467,22 @@ class TerrainViewerGUI:
             messagebox.showerror("Erro", str(exc))
 
     def save_png(self) -> None:
+        try:
+            (
+                world_path,
+                _,
+                _,
+                _,
+                _,
+                view_mode,
+                overlay,
+                _,
+                _,
+                params,
+            ) = self._gather_context()
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Erro", str(exc))
+            return
         output_path = filedialog.asksaveasfilename(
             title="Salvar visualização",
             defaultextension=".png",
@@ -918,12 +1491,34 @@ class TerrainViewerGUI:
         if not output_path:
             return
         try:
-            self._run(show=False, output=Path(output_path))
+            destination = Path(output_path)
+            if self._can_reuse_last(params) and self.last_result is not None:
+                title = (
+                    f"{world_path.name} (mapa {self.last_result.map_id}) —"
+                    f" {len(self.last_result.objects)} objetos"
+                )
+                render_scene(
+                    self.last_result.data,
+                    self.last_result.objects,
+                    output=destination,
+                    show=False,
+                    title=title,
+                    enable_object_edit=False,
+                    view_mode=view_mode,
+                    overlay=overlay,
+                )
+            else:
+                self._run(show=False, output=destination)
             messagebox.showinfo("Sucesso", f"PNG salvo em {output_path}")
         except Exception as exc:  # noqa: BLE001
             messagebox.showerror("Erro", str(exc))
 
     def export_objects(self) -> None:
+        try:
+            (_, _, _, _, _, _, _, _, _, params) = self._gather_context()
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Erro", str(exc))
+            return
         output_path = filedialog.asksaveasfilename(
             title="Exportar objetos",
             defaultextension=".csv",
@@ -932,8 +1527,62 @@ class TerrainViewerGUI:
         if not output_path:
             return
         try:
-            self._run(show=False, export_objects=Path(output_path), render=False)
+            destination = Path(output_path)
+            if self._can_reuse_last(params) and self.last_result is not None:
+                export_objects_csv(self.last_result, destination)
+            else:
+                self._run(show=False, export_objects=destination, render=False)
             messagebox.showinfo("Sucesso", f"Lista exportada para {output_path}")
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Erro", str(exc))
+
+    def export_json(self) -> None:
+        try:
+            (_, _, _, _, _, _, _, _, _, params) = self._gather_context()
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Erro", str(exc))
+            return
+        output_path = filedialog.asksaveasfilename(
+            title="Exportar JSON",
+            defaultextension=".json",
+            filetypes=[("JSON", "*.json")],
+        )
+        if not output_path:
+            return
+        try:
+            destination = Path(output_path)
+            if self._can_reuse_last(params) and self.last_result is not None:
+                export_result_json(self.last_result, destination)
+            else:
+                self._run(show=False, export_json=destination, render=False)
+            messagebox.showinfo("Sucesso", f"JSON salvo em {output_path}")
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Erro", str(exc))
+
+    def save_objects_dialog(self) -> None:
+        try:
+            (_, _, _, _, _, _, _, _, _, params) = self._gather_context()
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Erro", str(exc))
+            return
+        output_path = filedialog.asksaveasfilename(
+            title="Salvar arquivo EncTerrain",
+            defaultextension=".obj",
+            filetypes=[("EncTerrain", "*.obj")],
+        )
+        if not output_path:
+            return
+        destination = Path(output_path)
+        try:
+            if self._can_reuse_last(params) and self.last_result is not None:
+                save_objects_file(self.last_result, destination)
+            else:
+                self._run(
+                    show=False,
+                    render=False,
+                    save_objects_path=destination,
+                )
+            messagebox.showinfo("Sucesso", f"EncTerrain salvo em {output_path}")
         except Exception as exc:  # noqa: BLE001
             messagebox.showerror("Erro", str(exc))
 
@@ -954,15 +1603,24 @@ class TerrainViewerGUI:
         show: bool,
         output: Optional[Path] = None,
         export_objects: Optional[Path] = None,
+        export_json: Optional[Path] = None,
+        save_objects_path: Optional[Path] = None,
         render: Optional[bool] = None,
     ) -> TerrainLoadResult:
-        world_path = self._current_world_path()
-        if world_path is None:
-            raise ValueError("Selecione uma pasta World válida.")
-        map_id = _safe_int(self.map_id_var.get())
-        height_scale = self._parse_float(self.height_scale_var.get())
-        max_objects = _safe_int(self.max_objects_var.get())
-        object_dir = Path(self.object_dir_var.get()) if self.object_dir_var.get() else None
+        (
+            world_path,
+            map_id,
+            height_scale,
+            max_objects,
+            object_dir,
+            view_mode,
+            overlay,
+            include,
+            exclude,
+            params,
+        ) = self._gather_context()
+        include_filters = [include] if include else None
+        exclude_filters = [exclude] if exclude else None
         result = run_viewer(
             world_path,
             map_id=map_id,
@@ -978,10 +1636,18 @@ class TerrainViewerGUI:
             detailed_summary=False,
             summary_limit=5,
             render=(render if render is not None else (show or output is not None)),
+            enable_object_edit=self.edit_objects_var.get(),
+            view_mode=view_mode,
+            overlay=overlay,
+            include_filters=include_filters,
+            exclude_filters=exclude_filters,
+            export_json=export_json,
+            save_objects=save_objects_path,
         )
         self.map_id_var.set(str(result.map_id))
         self.status_var.set(format_summary_line(result))
         self.last_result = result
+        self.last_params = params
         return result
 
     @staticmethod
@@ -1037,6 +1703,23 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         help="Salva um CSV com a lista completa de objetos posicionados no mapa.",
     )
     parser.add_argument(
+        "--export-json",
+        type=Path,
+        dest="export_json",
+        help="Exporta os dados visíveis em JSON para automação externa.",
+    )
+    parser.add_argument(
+        "--edit-objects",
+        action="store_true",
+        help="Permite mover objetos na visualização interativa (setas do teclado).",
+    )
+    parser.add_argument(
+        "--save-objects",
+        type=Path,
+        dest="save_objects",
+        help="Gera um novo arquivo EncTerrainXX.obj com as posições atuais.",
+    )
+    parser.add_argument(
         "--detailed-summary",
         action="store_true",
         help="Mostra estatísticas adicionais (altura, atributos e texturas).",
@@ -1046,6 +1729,30 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         type=int,
         default=8,
         help="Quantidade de entradas exibidas nos resumos de objetos.",
+    )
+    parser.add_argument(
+        "--view-mode",
+        choices=["3d", "2d"],
+        default="3d",
+        help="Define se a visualização será 3D tradicional ou 2D com heatmap.",
+    )
+    parser.add_argument(
+        "--overlay",
+        choices=["textures", "height", "attributes"],
+        default="textures",
+        help="Coloração aplicada ao terreno (texturas, altura ou atributos).",
+    )
+    parser.add_argument(
+        "--filter",
+        dest="include_filters",
+        action="append",
+        help="Inclui apenas objetos cujo ID ou nome contenha o texto informado.",
+    )
+    parser.add_argument(
+        "--exclude",
+        dest="exclude_filters",
+        action="append",
+        help="Oculta objetos cujo ID ou nome contenha o texto informado.",
     )
     args = parser.parse_args(argv)
 
@@ -1068,6 +1775,13 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         detailed_summary=args.detailed_summary,
         summary_limit=args.summary_limit,
         render=not args.no_show or args.output is not None,
+        enable_object_edit=args.edit_objects,
+        view_mode=args.view_mode,
+        overlay=args.overlay,
+        include_filters=args.include_filters,
+        exclude_filters=args.exclude_filters,
+        export_json=args.export_json,
+        save_objects=args.save_objects,
     )
 
 


### PR DESCRIPTION
## Summary
- add helper utilities that power the new 2D view, overlay selection, filtering and object persistence/export flows in the terrain viewer core and CLI
- expose the new controls in the GUI, reusing loaded data when exporting PNG, CSV, JSON or EncTerrain outputs
- document the extended workflows and command-line options, including new examples for 2D heatmaps and automation

## Testing
- python -m compileall tools/terrain_viewer/terrain_viewer.py

------
https://chatgpt.com/codex/tasks/task_e_68e433b632f083328f164d01d3db5f46