### PR TITLE
Align terrain_viewer TerrainLight selection with game logic

### DIFF
--- a/docs/terrain_viewer_status.md
+++ b/docs/terrain_viewer_status.md
@@ -1,0 +1,24 @@
+# Estado do `terrain_viewer`
+
+## Cobertura atual em relação ao cliente legado
+
+### Carregamento de terreno e atributos
+* O utilitário Python reproduz a rotina de decodificação `MapFileDecrypt`, aplica o mesmo XOR/Bux e valida cabeçalhos para `EncTerrain*.att` e `EncTerrain*.map`, reconstituindo as camadas de textura, alpha e atributos exatamente como o cliente C++.【F:tools/terrain_viewer/terrain_viewer.py†L973-L999】【F:tools/terrain_viewer/terrain_viewer.py†L3063-L3113】【F:source/ZzzLodTerrain.cpp†L131-L205】【F:source/ZzzLodTerrain.cpp†L285-L343】
+* Os dois formatos de altura (`TerrainHeight.OZB` clássico e `TerrainHeightNew.OZB`) são suportados com os mesmos fatores de escala utilizados pelo jogo original.【F:tools/terrain_viewer/terrain_viewer.py†L3116-L3141】【F:source/ZzzLodTerrain.cpp†L513-L596】
+* As texturas de tile são buscadas pelas mesmas convenções de nomes, com fallback para índices estendidos, replicando o carregamento feito pelo `MapManager` no cliente.【F:tools/terrain_viewer/terrain_viewer.py†L801-L915】【F:source/MapManager.cpp†L1440-L1499】
+
+### Objetos estáticos (`EncTerrain*.obj`)
+* O parser Python lê `EncTerrain*.obj`, preserva versão, ID de mapa, posições, rotações e escala, atribui nomes usando `_enum.h` e pode exportar novamente com o algoritmo inverso de encriptação, mantendo compatibilidade com o formato original.【F:tools/terrain_viewer/terrain_viewer.py†L3144-L3187】【F:tools/terrain_viewer/terrain_viewer.py†L3966-L4025】【F:tools/terrain_viewer/terrain_viewer.py†L4168-L4183】【F:source/ZzzObject.cpp†L5057-L5118】
+
+### Renderização e recursos gráficos
+* O modo OpenGL reconstrói a malha do terreno com normal map, máscara de sombras e atributos por tile, além de combinar texturas em múltiplas camadas como o cliente DirectX9, permitindo iluminação dinâmica e materiais especiais (água, lava, aditivos).【F:tools/terrain_viewer/terrain_viewer.py†L1684-L1814】【F:tools/terrain_viewer/terrain_viewer.py†L2586-L3033】
+* Modelos BMD são carregados com ossos, animações, eventos e attachments; o `BMDAnimationPlayer` realiza blending e skinning idênticos ao pipeline do cliente.【F:tools/terrain_viewer/terrain_viewer.py†L544-L689】【F:tools/terrain_viewer/terrain_viewer.py†L1880-L2117】【F:source/ZzzBMD.cpp†L55-L166】
+* O utilitário expõe o mesmo conjunto de saídas auxiliares (resumo estatístico, exportação CSV/JSON e regravação de `EncTerrain`) que facilitam auditoria e edição externa, algo inexistente no executável legado.【F:tools/terrain_viewer/terrain_viewer.py†L4028-L4200】【F:tools/terrain_viewer/terrain_viewer.py†L4680-L4973】
+* A iluminação estática replica o carregamento de `TerrainLight*.jpg` e o cálculo de luminosidade do cliente: o `TextureLibrary` prioriza as variantes corretas para Battle Castle/Crywolf, usa o mesmo vetor direcional e multiplica tanto a malha Matplotlib quanto o pipeline OpenGL pelo mapa de luz e pelo dot product com as normais.【F:tools/terrain_viewer/terrain_viewer.py†L823-L1017】【F:tools/terrain_viewer/terrain_viewer.py†L1873-L1908】【F:source/MapManager.cpp†L1388-L1435】【F:source/ZzzLodTerrain.cpp†L411-L437】
+
+## Pontos ainda diferentes do cliente original
+* O viewer ignora rotinas de tempo real do cliente, como troca dinâmica de texturas de luz/neblina em eventos (`MapManager::CreateTerrain`, `SetTerrainWaterState`) ou geração procedural de grama animada, portanto o clima e certos efeitos dependentes do estado do servidor não são reproduzidos automaticamente.【F:source/ZzzLodTerrain.cpp†L260-L343】【F:source/MapManager.cpp†L1381-L1439】
+* Sistemas acoplados ao runtime (spawn de monstros, partículas específicas de eventos, lógica de colisão baseada em `TerrainWall`) permanecem exclusivos do executável C++, já que o script atua como ferramenta offline de inspeção/edição e não substitui o loop do jogo.
+
+## Conclusão
+O `terrain_viewer` cobre integralmente o pipeline de leitura de terreno/objetos e fornece um renderer equivalente (com modos OpenGL e Matplotlib), suficiente para reproduzir a cena estática do jogo e editar `EncTerrain`. As diferenças residem apenas em efeitos em tempo real e integração com sistemas de gameplay, que estão fora do escopo da ferramenta, indicando que a implementação atual já está funcionalmente alinhada ao projeto para visualização e edição offline.

--- a/tools/terrain_viewer/terrain_viewer.py
+++ b/tools/terrain_viewer/terrain_viewer.py
@@ -805,15 +805,43 @@ class TextureLibrary:
         *,
         detail_factor: int = 2,
         object_path: Optional[Path] = None,
+        map_id: Optional[int] = None,
     ) -> None:
         self.world_path = world_path
         self.detail_factor = max(1, detail_factor)
         self.object_path = object_path
+        self.map_id = map_id
         self._image_cache: Dict[int, Optional[np.ndarray]] = {}
         self._resized_cache: Dict[Tuple[int, int], np.ndarray] = {}
         self._missing: set[int] = set()
         self._fallback_cmap = cm.get_cmap("tab20")
         self.search_roots = self._build_search_roots()
+        self._light_image_loaded = False
+        self._light_image_uint8: Optional[np.ndarray] = None
+        self._light_map_cache: Dict[int, np.ndarray] = {}
+
+    def _light_candidates(self) -> List[str]:
+        base = [
+            "TerrainLight",
+            "TerrainLight0",
+            "TerrainLight1",
+            "TerrainLight2",
+            "TerrainLight3",
+        ]
+        prioritized: List[str] = []
+        if self.map_id == 30:  # Battle Castle
+            prioritized.extend(["TerrainLight2", "TerrainLight"])
+        elif self.map_id == 34:  # Crywolf
+            prioritized.extend(["TerrainLight", "TerrainLight1", "TerrainLight2"])
+
+        ordered: List[str] = []
+        seen: Set[str] = set()
+        for name in itertools.chain(prioritized, base):
+            if name in seen:
+                continue
+            seen.add(name)
+            ordered.append(name)
+        return ordered
 
     def _build_search_roots(self) -> List[Path]:
         roots: List[Path] = []
@@ -833,6 +861,57 @@ class TextureLibrary:
                     if lowered.startswith("object") or lowered.startswith("world"):
                         add(child)
         return roots
+
+    def _load_light_image(self) -> Optional[np.ndarray]:
+        if self._light_image_loaded:
+            return self._light_image_uint8
+        self._light_image_loaded = True
+        search = [self.world_path]
+        for name in self._light_candidates():
+            for path in _iter_candidate_paths(search, name, IMAGE_EXTENSIONS):
+                image = _load_image_file(path)
+                if image is None:
+                    continue
+                if image.ndim == 2:
+                    rgb = np.stack([image, image, image], axis=-1)
+                else:
+                    rgb = image[..., :3]
+                rgb_uint8 = np.asarray(rgb, dtype=np.uint8)
+                self._light_image_uint8 = rgb_uint8
+                base_size = rgb_uint8.shape[0]
+                self._light_map_cache[base_size] = rgb_uint8.astype(np.float32) / 255.0
+                return self._light_image_uint8
+        self._light_image_uint8 = None
+        return None
+
+    def light_map_texture(self, target_size: int) -> Optional[np.ndarray]:
+        if target_size <= 0:
+            return None
+        if target_size in self._light_map_cache:
+            return self._light_map_cache[target_size]
+        source = self._load_light_image()
+        if source is None:
+            return None
+        rgb = source[..., :3]
+        if rgb.shape[0] == target_size and rgb.shape[1] == target_size:
+            result = rgb.astype(np.float32) / 255.0
+        else:
+            image = Image.fromarray(rgb)
+            resized = image.resize((target_size, target_size), Image.BILINEAR)
+            result = np.asarray(resized, dtype=np.float32) / 255.0
+        if result.ndim == 2:
+            result = np.stack([result, result, result], axis=-1)
+        elif result.shape[2] == 4:
+            result = result[:, :, :3]
+        self._light_map_cache[target_size] = result.astype(np.float32)
+        return self._light_map_cache[target_size]
+
+    def light_direction(self) -> np.ndarray:
+        if self.map_id == 30:
+            direction = np.array([-0.5, 1.0, -1.0], dtype=np.float32)
+        else:
+            direction = np.array([-0.5, 0.5, -0.5], dtype=np.float32)
+        return _normalize(direction)
 
     def _fallback_color(self, index: int) -> np.ndarray:
         rgba = self._fallback_cmap((index % 20) / 20.0)
@@ -924,8 +1003,18 @@ class TextureLibrary:
         y_coords = np.linspace(0.0, float(TERRAIN_SIZE - 1), refined_heights.shape[0], dtype=np.float32)
         xx, yy = np.meshgrid(x_coords, y_coords)
         facecolors = np.clip(texture_pixels[:-1, :-1, :], 0.0, 1.0)
-        shading = LightSource(azdeg=315, altdeg=55).shade(refined_heights, vert_exag=1.0, fraction=0.6)
-        facecolors[..., :3] *= np.clip(shading[:-1, :-1, :], 0.0, 1.0)
+        normals = _compute_normal_map(refined_heights, float(TERRAIN_SCALE) / float(self.detail_factor))
+        if normals.size == 0:
+            shading_rgb = np.ones((facecolors.shape[0], facecolors.shape[1], 3), dtype=np.float32)
+        else:
+            light_dir = self.light_direction()
+            luminosity = np.sum(normals * light_dir.reshape(1, 1, 3), axis=2)
+            luminosity = np.clip(luminosity + 0.5, 0.0, 1.0)
+            shading_rgb = np.repeat(luminosity[:, :, None], 3, axis=2)
+            light_map = self.light_map_texture(texture_pixels.shape[0])
+            if light_map is not None:
+                shading_rgb *= np.clip(light_map[:-1, :-1, :3], 0.0, 1.0)
+        facecolors[..., :3] *= shading_rgb
         facecolors = np.clip(facecolors, 0.0, 1.0)
         return xx, yy, refined_heights, facecolors
 
@@ -1694,6 +1783,7 @@ class _TerrainBuffers:
     ) -> None:
         detail = texture_library.detail_factor
         heights = _upsample_height_map(data.height, detail)
+        light_dir = texture_library.light_direction()
         tile_flags = compute_tile_material_flags(
             data.mapping_layer1,
             data.mapping_layer2,
@@ -1705,7 +1795,7 @@ class _TerrainBuffers:
         normal_map = _compute_normal_map(heights, spacing)
         shadow_mask = _compute_shadow_mask(
             heights,
-            np.array([-0.35, -1.0, -0.45], dtype=np.float32),
+            light_dir,
             spacing,
         )
         if detail > 1:
@@ -1797,6 +1887,25 @@ class _TerrainBuffers:
         self.texture.filter = (moderngl.LINEAR_MIPMAP_LINEAR, moderngl.LINEAR)
         self.texture.repeat_x = True
         self.texture.repeat_y = True
+        refined_heights = _bilinear_resize(data.height, detail)
+        refined_normals = _compute_normal_map(refined_heights, float(TERRAIN_SCALE) / float(detail))
+        if refined_normals.size == 0:
+            lum_rgb = np.ones((height_px - 1, width_px - 1, 3), dtype=np.float32)
+        else:
+            luminosity = np.sum(refined_normals * light_dir.reshape(1, 1, 3), axis=2)
+            luminosity = np.clip(luminosity + 0.5, 0.0, 1.0)
+            lum_rgb = np.repeat(luminosity[:, :, None], 3, axis=2)
+        light_rgb = np.ones((height_px, width_px, 3), dtype=np.float32)
+        light_rgb[:-1, :-1, :] *= lum_rgb
+        sampled_light_map = texture_library.light_map_texture(height_px)
+        if sampled_light_map is not None:
+            light_rgb *= np.clip(sampled_light_map[:, :, :3], 0.0, 1.0)
+        light_bytes = (np.clip(light_rgb, 0.0, 1.0) * 255).astype(np.uint8).tobytes()
+        self.light_texture = ctx.texture((light_rgb.shape[1], light_rgb.shape[0]), 3, light_bytes)
+        self.light_texture.build_mipmaps()
+        self.light_texture.filter = (moderngl.LINEAR_MIPMAP_LINEAR, moderngl.LINEAR)
+        self.light_texture.repeat_x = True
+        self.light_texture.repeat_y = True
         normal_pixels = np.clip((normal_map * 0.5) + 0.5, 0.0, 1.0)
         normal_bytes = (normal_pixels * 255).astype(np.uint8).tobytes()
         self.normal_texture = ctx.texture(
@@ -1812,6 +1921,7 @@ class _TerrainBuffers:
         self.shadow_texture.filter = (moderngl.LINEAR, moderngl.LINEAR)
         self.shadow_texture.repeat_x = True
         self.shadow_texture.repeat_y = True
+        self.light_direction = light_dir
 
 
 class _BMDMeshRenderer:
@@ -2202,7 +2312,7 @@ class OpenGLTerrainApp:
         self._particle_count = 0
         self._particle_vao: Optional["moderngl.VertexArray"] = None
         self.object_instances: List[BMDInstance] = []
-        self.directional_light_dir = np.array([-0.35, -1.0, -0.45], dtype=np.float32)
+        self.directional_light_dir = texture_library.light_direction()
         self.directional_light_color = np.array([1.0, 0.96, 0.88], dtype=np.float32)
         self.shadow_strength = 0.65
         self.static_point_lights: List[Tuple[np.ndarray, np.ndarray, float]] = []
@@ -2248,6 +2358,7 @@ class OpenGLTerrainApp:
                 uniform sampler2D u_texture;
                 uniform sampler2D u_normal_map;
                 uniform sampler2D u_shadow_map;
+                uniform sampler2D u_light_map;
                 uniform vec3 u_dir_light_dir;
                 uniform vec3 u_dir_light_color;
                 uniform int u_point_light_count;
@@ -2288,7 +2399,8 @@ class OpenGLTerrainApp:
                     if ((v_material & FLAG_ALPHA_TEST) != 0 && alpha < 0.35) {
                         discard;
                     }
-                    vec3 base_color = tex.rgb;
+                    vec3 static_light = texture(u_light_map, v_uv).rgb;
+                    vec3 base_color = tex.rgb * static_light;
                     vec3 map_normal = texture(u_normal_map, v_uv).xyz * 2.0 - 1.0;
                     vec3 normal = normalize(v_normal);
                     if (wave != 0.0) {
@@ -2814,6 +2926,8 @@ class OpenGLTerrainApp:
             self.overlay,
             self.material_library,
         )
+        if self.terrain is not None:
+            self.directional_light_dir = self.terrain.light_direction
         self._initialize_sky_texture()
         self.object_instances = self._load_objects()
         self._build_static_lights()
@@ -2951,6 +3065,10 @@ class OpenGLTerrainApp:
             terrain.normal_texture.use(location=1)
         if terrain.shadow_texture is not None:
             terrain.shadow_texture.use(location=2)
+        if terrain.light_texture is not None:
+            terrain.light_texture.use(location=3)
+        elif self._default_white_texture is not None:
+            self._default_white_texture.use(location=3)
         model_identity = np.eye(4, dtype=np.float32)
         self.ctx.disable(moderngl.BLEND)
         self.ctx.enable(moderngl.DEPTH_TEST)
@@ -2962,6 +3080,7 @@ class OpenGLTerrainApp:
             self.terrain_program["u_normal_map"].value = 1
         if terrain.shadow_texture is not None:
             self.terrain_program["u_shadow_map"].value = 2
+        self.terrain_program["u_light_map"].value = 3
         self.terrain_program["u_dir_light_dir"].value = tuple(dir_light.tolist())
         self.terrain_program["u_dir_light_color"].value = tuple(self.directional_light_color.tolist())
         self.terrain_program["u_point_light_count"].value = point_count
@@ -4300,6 +4419,7 @@ def run_viewer(
                 display_result.world_path,
                 detail_factor=max(1, texture_detail),
                 object_path=object_path,
+                map_id=display_result.map_id,
             )
             material_roots: List[Path] = []
             if object_path:
@@ -4313,6 +4433,7 @@ def run_viewer(
                 display_result.world_path,
                 detail_factor=max(1, texture_detail),
                 object_path=object_path,
+                map_id=display_result.map_id,
             )
 
         bmd_library: Optional[BMDLibrary] = None
@@ -4786,6 +4907,7 @@ class TerrainViewerGUI:
                         world_path,
                         detail_factor=max(1, texture_detail),
                         object_path=object_dir,
+                        map_id=self.last_result.map_id,
                     )
                 material_library = None
                 bmd_library = None


### PR DESCRIPTION
## Summary
- prioritize the correct TerrainLight variant order for Battle Castle and Crywolf so cached lighting matches the game's loader
- keep Matplotlib and OpenGL shading in sync by reusing the directional light map across both pipelines
- document the static-light parity between the viewer and the legacy client

## Testing
- python -m compileall tools/terrain_viewer/terrain_viewer.py

------
https://chatgpt.com/codex/tasks/task_e_68e5689f3b288332a7b9c4aca9e684ec