### PR TITLE
Fix Matplotlib shading regression in terrain viewer

### DIFF
--- a/tools/terrain_viewer/terrain_viewer.py
+++ b/tools/terrain_viewer/terrain_viewer.py
@@ -3681,11 +3681,12 @@ def render_scene(
         cmap = plt.get_cmap(cmap_name)
         normalized = _normalize_for_colormap(matrix)
         base_colors = cmap(normalized)
-        facecolors = base_colors[:-1, :-1, :]
-        shading = LightSource(azdeg=315, altdeg=55).shade(
-            render_heights, vert_exag=1.0, fraction=0.6
+        facecolors = base_colors[:-1, :-1, :].copy()
+        light_source = LightSource(azdeg=315, altdeg=55)
+        shaded_rgb = light_source.shade_rgb(
+            facecolors[..., :3], render_heights[:-1, :-1], fraction=0.6
         )
-        facecolors[..., :3] *= np.clip(shading[:-1, :-1, :], 0.0, 1.0)
+        facecolors[..., :3] = shaded_rgb
         facecolors = np.clip(facecolors, 0.0, 1.0)
 
     ax.plot_surface(


### PR DESCRIPTION
## Summary
- replace the Matplotlib LightSource.shade call with shade_rgb to support modern Matplotlib versions
- ensure the fallback terrain rendering path still applies dynamic lighting when OpenGL is unavailable

## Testing
- python - <<'PY'
from pathlib import Path
import sys
sys.path.append('Main')
import numpy as np
from tools.terrain_viewer.terrain_viewer import TerrainData, render_scene

data = TerrainData(
    height=np.random.rand(256,256).astype('float32')*300,
    mapping_layer1=np.zeros((256,256),dtype='uint8'),
    mapping_layer2=np.full((256,256),255,dtype='uint8'),
    mapping_alpha=np.zeros((256,256),dtype='float32'),
    attributes=np.zeros((256,256),dtype='uint16')
)
render_scene(data, [], output=Path('test.png'), show=False)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e5d0afef8883328858df82e4f18da6