### PR TITLE
Add WinForms UI for Terreno Visualisado

### DIFF
--- a/tools/terreno_visualisado/Program.cs
+++ b/tools/terreno_visualisado/Program.cs
@@ -1,0 +1,149 @@
+using System.Globalization;
+using TerrenoVisualisado.Core;
+
+namespace TerrenoVisualisado;
+
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        try
+        {
+            var options = CliOptions.Parse(args);
+            if (options.WorldDirectory is null)
+            {
+                throw new ArgumentException("Informe o diretório --world contendo os arquivos EncTerrain.");
+            }
+
+            var loader = new WorldLoader();
+            var world = loader.Load(options.WorldDirectory, new WorldLoader.LoadOptions
+            {
+                ObjectRoot = options.ObjectDirectory,
+                MapId = options.MapId,
+                EnumPath = options.EnumPath,
+                ForceExtendedHeight = options.ForceExtendedHeight,
+                HeightScale = options.HeightScale,
+            });
+
+            PrintSummary(world);
+            var output = options.OutputPath ?? "terrainsummary.json";
+            WorldExporter.WriteJson(world, output);
+            Console.WriteLine($"Resumo salvo em {output}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Erro: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static void PrintSummary(WorldData world)
+    {
+        Console.WriteLine($"Diretório: {world.WorldPath}");
+        Console.WriteLine($"Mapa detectado: {world.MapId}");
+        Console.WriteLine($"Objetos: {world.Objects.Count} (versão {world.ObjectVersion})");
+
+        var tileCounts = new Dictionary<byte, int>();
+        for (var i = 0; i < WorldLoader.TerrainSize * WorldLoader.TerrainSize; i++)
+        {
+            Increment(world.Terrain.Layer1[i]);
+            Increment(world.Terrain.Layer2[i]);
+        }
+
+        Console.WriteLine("Top tiles por frequência:");
+        foreach (var (tile, count) in tileCounts.OrderByDescending(kv => kv.Value).Take(8))
+        {
+            Console.WriteLine($"  Tile {tile:D3}: {count} ocorrências");
+        }
+
+        var attributeCounts = new Dictionary<ushort, int>();
+        foreach (var attr in world.Terrain.Attributes)
+        {
+            attributeCounts.TryGetValue(attr, out var count);
+            attributeCounts[attr] = count + 1;
+        }
+        Console.WriteLine("Atributos mais comuns:");
+        foreach (var (attr, count) in attributeCounts.OrderByDescending(kv => kv.Value).Take(8))
+        {
+            Console.WriteLine($"  0x{attr:X3}: {count} tiles");
+        }
+
+        var objectCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var obj in world.Objects)
+        {
+            var key = obj.TypeName ?? $"ID_{obj.TypeId}";
+            objectCounts.TryGetValue(key, out var count);
+            objectCounts[key] = count + 1;
+        }
+
+        Console.WriteLine("Objetos estáticos mais frequentes:");
+        foreach (var (name, count) in objectCounts.OrderByDescending(kv => kv.Value).Take(10))
+        {
+            Console.WriteLine($"  {name}: {count}");
+        }
+
+        void Increment(byte tile)
+        {
+            tileCounts.TryGetValue(tile, out var count);
+            tileCounts[tile] = count + 1;
+        }
+    }
+
+    private sealed record CliOptions
+    {
+        public string? WorldDirectory { get; init; }
+        public string? ObjectDirectory { get; init; }
+        public int? MapId { get; init; }
+        public string? EnumPath { get; init; }
+        public float? HeightScale { get; init; }
+        public bool ForceExtendedHeight { get; init; }
+        public string? OutputPath { get; init; }
+
+        public static CliOptions Parse(string[] args)
+        {
+            var options = new CliOptions();
+            for (var i = 0; i < args.Length; i++)
+            {
+                var arg = args[i];
+                switch (arg)
+                {
+                    case "--world":
+                        options.WorldDirectory = RequireValue(args, ref i, arg);
+                        break;
+                    case "--objects":
+                        options.ObjectDirectory = RequireValue(args, ref i, arg);
+                        break;
+                    case "--map":
+                        options.MapId = int.Parse(RequireValue(args, ref i, arg), CultureInfo.InvariantCulture);
+                        break;
+                    case "--enum":
+                        options.EnumPath = RequireValue(args, ref i, arg);
+                        break;
+                    case "--height-scale":
+                        options.HeightScale = float.Parse(RequireValue(args, ref i, arg), CultureInfo.InvariantCulture);
+                        break;
+                    case "--extended-height":
+                        options.ForceExtendedHeight = true;
+                        break;
+                    case "--output":
+                        options.OutputPath = RequireValue(args, ref i, arg);
+                        break;
+                    default:
+                        throw new ArgumentException($"Argumento desconhecido: {arg}");
+                }
+            }
+            return options;
+        }
+
+        private static string RequireValue(IReadOnlyList<string> args, ref int index, string name)
+        {
+            if (index + 1 >= args.Count)
+            {
+                throw new ArgumentException($"O argumento {name} requer um valor.");
+            }
+            index++;
+            return args[index];
+        }
+    }
+}

--- a/tools/terreno_visualisado/README.md
+++ b/tools/terreno_visualisado/README.md
@@ -1,0 +1,55 @@
+# Terreno Visualisado
+
+O **Terreno Visualisado** é um utilitário em C# que reproduz o pipeline de
+carregamento dos arquivos `EncTerrain` usado pela Main.exe. Ele descriptografa os
+arquivos `.map`, `.att`, `.obj` e `TerrainHeight*.OZB`, reconstrói as camadas de
+tiles e reposiciona os objetos estáticos para facilitar a inspeção rápida dos
+dados sem executar o cliente completo.
+
+## Pré-requisitos
+
+* [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) ou superior.
+
+## Compilação
+
+Dentro da raiz do repositório execute:
+
+```bash
+dotnet build tools/terreno_visualisado/TerrenoVisualisado.csproj -c Release
+# Interface gráfica WinForms (requer Windows)
+dotnet build tools/terreno_visualisado/TerrenoVisualisado.Gui/TerrenoVisualisado.Gui.csproj -c Release
+```
+
+## Uso
+
+```bash
+# Exemplo mínimo apontando para a pasta Data/World1 do cliente
+
+dotnet run --project tools/terreno_visualisado/TerrenoVisualisado.csproj -- \
+    --world /caminho/para/Data/World1
+```
+
+Opções principais:
+
+* `--world <pasta>`: diretório que contém `EncTerrain*.map/.att` e `TerrainHeight.OZB`.
+* `--objects <pasta>`: diretório `ObjectX` com o `EncTerrain*.obj` correspondente (opcional).
+* `--map <id>`: força o ID numérico usado nos arquivos `EncTerrain`.
+* `--enum <arquivo>`: caminho para o `_enum.h` para exibir o nome textual dos objetos.
+* `--height-scale <valor>`: fator aplicado ao `TerrainHeight.OZB` clássico.
+* `--extended-height`: força o uso do `TerrainHeightNew.OZB` mesmo que o clássico exista.
+
+A execução imprime um sumário contendo o ID detectado, o número total de tiles
+por material, a contagem de atributos especiais e um ranking com os tipos de
+objetos estáticos mais comuns. O utilitário também gera um arquivo JSON
+`terrainsummary.json` no diretório atual contendo todas as amostras de altura,
+camadas e objetos já alinhados ao terreno, permitindo integrações com outras
+ferramentas.
+
+## Interface gráfica
+
+O projeto `TerrenoVisualisado.Gui` oferece uma interface WinForms para
+visualizar rapidamente as camadas carregadas, alternar entre altura, layers,
+atributos e alfa, além de sobrepor os objetos estáticos nas posições corretas.
+A tela principal permite selecionar as pastas do mundo e dos objetos, informar
+um `EnumModelType.eum` opcional e ajustar escala/ID do mapa. Após o carregamento
+é possível exportar o mesmo JSON gerado pelo utilitário de linha de comando.

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/TerrenoVisualisado.Core.csproj
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/TerrenoVisualisado.Core.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldExporter.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldExporter.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+
+namespace TerrenoVisualisado.Core;
+
+public static class WorldExporter
+{
+    public static void WriteJson(WorldData world, string outputPath)
+    {
+        var export = new
+        {
+            world.WorldPath,
+            world.ObjectsPath,
+            world.MapId,
+            world.ObjectVersion,
+            Terrain = new
+            {
+                Size = WorldLoader.TerrainSize,
+                Height = world.Terrain.Height,
+                Layer1 = world.Terrain.Layer1,
+                Layer2 = world.Terrain.Layer2,
+                Alpha = world.Terrain.Alpha,
+                Attributes = world.Terrain.Attributes,
+            },
+            Objects = world.Objects.Select(obj => new
+            {
+                obj.TypeId,
+                obj.TypeName,
+                Position = new[] { obj.Position.X, obj.Position.Y, obj.Position.Z },
+                RawPosition = new[] { obj.RawPosition.X, obj.RawPosition.Y, obj.RawPosition.Z },
+                Rotation = new[] { obj.Rotation.X, obj.Rotation.Y, obj.Rotation.Z },
+                obj.Scale,
+            }),
+        };
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+        };
+        File.WriteAllText(outputPath, JsonSerializer.Serialize(export, options));
+    }
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldLoader.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldLoader.cs
@@ -1,0 +1,470 @@
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Numerics;
+using System.Text.RegularExpressions;
+
+namespace TerrenoVisualisado.Core;
+
+public sealed class WorldLoader
+{
+    public const int TerrainSize = 256;
+    private const float TerrainScale = 100.0f;
+    private const float DefaultClassicHeightScale = 1.5f;
+    private const float MinHeightBias = -500.0f;
+
+    private static readonly byte[] XorKey =
+    {
+        0xD1, 0x73, 0x52, 0xF6, 0xD2, 0x9A, 0xCB, 0x27,
+        0x3E, 0xAF, 0x59, 0x31, 0x37, 0xB3, 0xE7, 0xA2,
+    };
+
+    private static readonly byte[] BuxCode = { 0xFC, 0xCF, 0xAB };
+
+    public sealed class LoadOptions
+    {
+        public string? ObjectRoot { get; init; }
+        public int? MapId { get; set; }
+        public string? EnumPath { get; init; }
+        public bool ForceExtendedHeight { get; init; }
+        public float? HeightScale { get; init; }
+    }
+
+    public WorldData Load(string worldDirectory, LoadOptions options)
+    {
+        if (!Directory.Exists(worldDirectory))
+        {
+            throw new DirectoryNotFoundException($"Diretório inválido: {worldDirectory}");
+        }
+
+        options.MapId ??= InferMapId(worldDirectory);
+
+        var attributesPath = ResolveTerrainFile(worldDirectory, options.MapId, ".att");
+        var mappingPath = ResolveTerrainFile(worldDirectory, options.MapId, ".map");
+        var objectsPath = ResolveObjectsPath(worldDirectory, options.ObjectRoot, options.MapId);
+        var heightPath = ResolveHeightPath(worldDirectory, options.ForceExtendedHeight);
+        var modelNames = LoadModelNames(options.EnumPath);
+
+        var terrain = LoadTerrain(attributesPath, mappingPath, heightPath, options.ForceExtendedHeight, options.HeightScale, out var attributeMapId, out var mappingMapId);
+        var objects = LoadObjects(objectsPath, modelNames, out var version, out var objectMapId);
+
+        var resolvedMapId = options.MapId ?? (attributeMapId >= 0 ? attributeMapId : (mappingMapId >= 0 ? mappingMapId : objectMapId));
+        AlignObjectsToTerrain(objects, terrain);
+
+        return new WorldData
+        {
+            WorldPath = Path.GetFullPath(worldDirectory),
+            ObjectsPath = Path.GetFullPath(objectsPath),
+            MapId = resolvedMapId,
+            ObjectVersion = version,
+            Terrain = terrain,
+            Objects = objects,
+        };
+    }
+
+    private static void AlignObjectsToTerrain(List<ObjectInstance> objects, TerrainData terrain)
+    {
+        foreach (var obj in objects)
+        {
+            var tileX = obj.RawPosition.X / TerrainScale;
+            var tileY = obj.RawPosition.Y / TerrainScale;
+            var height = BilinearHeight(terrain, tileX, tileY);
+            obj.Position = new Vector3(obj.RawPosition.X, height, obj.RawPosition.Y);
+        }
+    }
+
+    public static float BilinearHeight(TerrainData terrain, float tileX, float tileY)
+    {
+        if (terrain.Height.Length == 0)
+        {
+            return 0.0f;
+        }
+
+        var maxIndex = TerrainSize - 1;
+        var x = Math.Clamp(tileX, 0.0f, maxIndex);
+        var y = Math.Clamp(tileY, 0.0f, maxIndex);
+
+        var xi = (int)MathF.Floor(x);
+        var yi = (int)MathF.Floor(y);
+        var xd = x - xi;
+        var yd = y - yi;
+
+        float Sample(int sx, int sy)
+        {
+            sx = Math.Clamp(sx, 0, maxIndex);
+            sy = Math.Clamp(sy, 0, maxIndex);
+            return terrain.Height[sy * TerrainSize + sx];
+        }
+
+        var h00 = Sample(xi, yi);
+        var h10 = Sample(xi + 1, yi);
+        var h01 = Sample(xi, yi + 1);
+        var h11 = Sample(xi + 1, yi + 1);
+
+        var h0 = h00 * (1 - xd) + h10 * xd;
+        var h1 = h01 * (1 - xd) + h11 * xd;
+        return h0 * (1 - yd) + h1 * yd;
+    }
+
+    private static List<ObjectInstance> LoadObjects(string objectsPath, Dictionary<int, string> modelNames, out int version, out int mapId)
+    {
+        var raw = File.ReadAllBytes(objectsPath);
+        var decrypted = MapFileDecrypt(raw);
+        if (decrypted.Length < 4)
+        {
+            throw new InvalidDataException($"Arquivo EncTerrain.obj truncado: {objectsPath}");
+        }
+
+        var span = decrypted.AsSpan();
+        var index = 0;
+        version = span[index++];
+        mapId = span[index++];
+        var count = BinaryPrimitives.ReadInt16LittleEndian(span[index..]);
+        index += 2;
+        if (count < 0)
+        {
+            throw new InvalidDataException($"Contagem negativa de objetos em {objectsPath}");
+        }
+
+        var objects = new List<ObjectInstance>(count);
+        for (var i = 0; i < count; i++)
+        {
+            if (index + 34 > span.Length)
+            {
+                throw new InvalidDataException($"Dados de objeto insuficientes em {objectsPath}");
+            }
+
+            var typeId = BinaryPrimitives.ReadInt16LittleEndian(span[index..]);
+            index += 2;
+            var position = new Vector3(
+                BitConverter.ToSingle(span[index..(index + 4)]),
+                BitConverter.ToSingle(span[(index + 4)..(index + 8)]),
+                BitConverter.ToSingle(span[(index + 8)..(index + 12)]));
+            index += 12;
+            var rotation = new Vector3(
+                BitConverter.ToSingle(span[index..(index + 4)]),
+                BitConverter.ToSingle(span[(index + 4)..(index + 8)]),
+                BitConverter.ToSingle(span[(index + 8)..(index + 12)]));
+            index += 12;
+            var scale = BitConverter.ToSingle(span[index..(index + 4)]);
+            index += 4;
+
+            modelNames.TryGetValue(typeId, out var name);
+            objects.Add(new ObjectInstance
+            {
+                TypeId = typeId,
+                TypeName = name,
+                RawPosition = position,
+                Rotation = rotation,
+                Scale = scale,
+            });
+        }
+
+        return objects;
+    }
+
+    private static TerrainData LoadTerrain(string attributesPath, string mappingPath, string heightPath, bool forceExtendedHeight, float? heightScale, out int attributeMapId, out int mappingMapId)
+    {
+        var height = new float[TerrainSize * TerrainSize];
+        var layer1 = new byte[TerrainSize * TerrainSize];
+        var layer2 = new byte[TerrainSize * TerrainSize];
+        var alpha = new float[TerrainSize * TerrainSize];
+        var attributes = new ushort[TerrainSize * TerrainSize];
+
+        // atributos
+        {
+            var raw = File.ReadAllBytes(attributesPath);
+            var decrypted = MapFileDecrypt(raw);
+            BuxConvert(decrypted);
+            if (decrypted.Length != 131076 && decrypted.Length != 65540)
+            {
+                throw new InvalidDataException($"Tamanho inesperado para arquivo de atributos: {attributesPath}");
+            }
+            attributeMapId = decrypted[1];
+            const int offset = 4;
+            if (decrypted.Length == 65540)
+            {
+                for (var i = 0; i < attributes.Length; i++)
+                {
+                    attributes[i] = decrypted[offset + i];
+                }
+            }
+            else
+            {
+                var span = decrypted.AsSpan(offset);
+                for (var i = 0; i < attributes.Length; i++)
+                {
+                    attributes[i] = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(i * 2, 2));
+                }
+            }
+        }
+
+        // mapping
+        {
+            var raw = File.ReadAllBytes(mappingPath);
+            var decrypted = MapFileDecrypt(raw);
+            if (decrypted.Length < 2 + TerrainSize * TerrainSize * 3)
+            {
+                throw new InvalidDataException($"Arquivo EncTerrain.map truncado: {mappingPath}");
+            }
+            mappingMapId = decrypted[1];
+            var index = 2;
+            for (var i = 0; i < layer1.Length; i++)
+            {
+                layer1[i] = decrypted[index++];
+            }
+            for (var i = 0; i < layer2.Length; i++)
+            {
+                layer2[i] = decrypted[index++];
+            }
+            for (var i = 0; i < alpha.Length; i++)
+            {
+                alpha[i] = decrypted[index++] / 255.0f;
+            }
+        }
+
+        // height
+        {
+            var raw = File.ReadAllBytes(heightPath);
+            if (raw.Length < 4)
+            {
+                throw new InvalidDataException($"Arquivo de altura muito pequeno: {heightPath}");
+            }
+            var payload = raw.AsSpan(4);
+            var extended = forceExtendedHeight || Path.GetFileName(heightPath).Equals("TerrainHeightNew.OZB", StringComparison.OrdinalIgnoreCase);
+            if (!extended)
+            {
+                var expected = 1080 + height.Length;
+                if (payload.Length < expected)
+                {
+                    throw new InvalidDataException($"Arquivo de altura clássico truncado: {heightPath}");
+                }
+                var scale = heightScale ?? DefaultClassicHeightScale;
+                var heightBytes = payload.Slice(1080);
+                for (var i = 0; i < height.Length; i++)
+                {
+                    height[i] = heightBytes[i] * scale;
+                }
+            }
+            else
+            {
+                const int headerSize = 14 + 40;
+                var expected = headerSize + height.Length * 3;
+                if (payload.Length < expected)
+                {
+                    throw new InvalidDataException($"Arquivo TerrainHeightNew.OZB truncado: {heightPath}");
+                }
+                var pixel = payload.Slice(headerSize);
+                for (var i = 0; i < height.Length; i++)
+                {
+                    var b = pixel[i * 3 + 0];
+                    var g = pixel[i * 3 + 1];
+                    var r = pixel[i * 3 + 2];
+                    var combined = (r << 16) | (g << 8) | b;
+                    var value = (combined / 10.0f) + MinHeightBias;
+                    height[i] = value;
+                }
+            }
+        }
+
+        return new TerrainData(height, layer1, layer2, alpha, attributes);
+    }
+
+    private static Dictionary<int, string> LoadModelNames(string? enumPath)
+    {
+        var path = enumPath ?? "..\\data\\EnumModelType.eum";
+        if (!File.Exists(path))
+        {
+            return new Dictionary<int, string>();
+        }
+
+        var regex = new Regex(@"^(?<id>\d+)\s*,\s*\"(?<name>[^\"]+)\"", RegexOptions.Compiled);
+        var map = new Dictionary<int, string>();
+        foreach (var line in File.ReadLines(path))
+        {
+            var match = regex.Match(line);
+            if (match.Success)
+            {
+                var id = int.Parse(match.Groups["id"].Value, CultureInfo.InvariantCulture);
+                var name = match.Groups["name"].Value;
+                map[id] = name;
+            }
+        }
+        return map;
+    }
+
+    private static string ResolveObjectsPath(string worldDirectory, string? objectRoot, int? mapId)
+    {
+        if (!string.IsNullOrEmpty(objectRoot))
+        {
+            var explicitPath = ResolveTerrainFile(objectRoot, mapId, ".obj");
+            if (!string.IsNullOrEmpty(explicitPath))
+            {
+                return explicitPath;
+            }
+        }
+
+        if (GuessObjectFolder(worldDirectory) is { } guessed)
+        {
+            return ResolveTerrainFile(guessed, mapId, ".obj");
+        }
+
+        throw new FileNotFoundException("Arquivo EncTerrain*.obj não encontrado. Utilize --objects para informar a pasta correta.");
+    }
+
+    private static string ResolveHeightPath(string worldDirectory, bool preferExtended)
+    {
+        var classic = Path.Combine(worldDirectory, "TerrainHeight.OZB");
+        var extended = Path.Combine(worldDirectory, "TerrainHeightNew.OZB");
+
+        bool classicValid = File.Exists(classic) && new FileInfo(classic).Length >= 4 + 1080 + TerrainSize * TerrainSize;
+        bool extendedValid = File.Exists(extended) && new FileInfo(extended).Length >= 4 + 54 + TerrainSize * TerrainSize * 3;
+
+        if (preferExtended && extendedValid)
+        {
+            return extended;
+        }
+        if (classicValid)
+        {
+            return classic;
+        }
+        if (extendedValid)
+        {
+            return extended;
+        }
+        throw new FileNotFoundException("Arquivos TerrainHeight.OZB ou TerrainHeightNew.OZB não encontrados ou inválidos.");
+    }
+
+    private static string ResolveTerrainFile(string directory, int? mapId, string extension)
+    {
+        if (!Directory.Exists(directory))
+        {
+            throw new DirectoryNotFoundException($"Diretório inválido: {directory}");
+        }
+
+        var matches = Directory.EnumerateFiles(directory, "EncTerrain*" + extension, SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (matches.Count == 0)
+        {
+            throw new FileNotFoundException($"Arquivos EncTerrain não encontrados em {directory}");
+        }
+
+        if (mapId.HasValue)
+        {
+            foreach (var candidate in matches)
+            {
+                if (ExtractDigits(Path.GetFileName(candidate)) is { } digits && digits == mapId.Value)
+                {
+                    return candidate;
+                }
+            }
+            throw new FileNotFoundException($"Nenhum arquivo EncTerrain correspondente ao mapa {mapId} foi encontrado em {directory}");
+        }
+
+        return matches[0];
+    }
+
+    private static string? GuessObjectFolder(string worldDirectory)
+    {
+        var info = new DirectoryInfo(worldDirectory);
+        var name = info.Name;
+        if (name.StartsWith("World", StringComparison.OrdinalIgnoreCase) && name.Length > 5)
+        {
+            var suffix = name[5..];
+            var candidate = Path.Combine(info.Parent?.FullName ?? info.FullName, "Object" + suffix);
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+            var lowerCandidate = Path.Combine(info.Parent?.FullName ?? info.FullName, "object" + suffix);
+            if (Directory.Exists(lowerCandidate))
+            {
+                return lowerCandidate;
+            }
+        }
+        return null;
+    }
+
+    private static int? InferMapId(string worldDirectory)
+    {
+        for (var dir = new DirectoryInfo(worldDirectory); dir != null; dir = dir.Parent)
+        {
+            if (dir.Name.StartsWith("World", StringComparison.OrdinalIgnoreCase) && ExtractDigits(dir.Name) is { } digits)
+            {
+                return digits;
+            }
+        }
+        return null;
+    }
+
+    private static int? ExtractDigits(string text)
+    {
+        var digits = new string(text.Where(char.IsDigit).ToArray());
+        if (digits.Length == 0)
+        {
+            return null;
+        }
+        return int.Parse(digits, CultureInfo.InvariantCulture);
+    }
+
+    private static byte[] MapFileDecrypt(byte[] input)
+    {
+        var output = new byte[input.Length];
+        byte wMapKey = 0x5E;
+        for (var i = 0; i < input.Length; i++)
+        {
+            var value = input[i];
+            var decrypted = (byte)(((value ^ XorKey[i % XorKey.Length]) - wMapKey) & 0xFF);
+            output[i] = decrypted;
+            wMapKey = (byte)((value + 0x3D) & 0xFF);
+        }
+        return output;
+    }
+
+    private static void BuxConvert(Span<byte> data)
+    {
+        for (var i = 0; i < data.Length; i++)
+        {
+            data[i] ^= BuxCode[i % BuxCode.Length];
+        }
+    }
+}
+
+public sealed class TerrainData
+{
+    public TerrainData(float[] height, byte[] layer1, byte[] layer2, float[] alpha, ushort[] attributes)
+    {
+        Height = height;
+        Layer1 = layer1;
+        Layer2 = layer2;
+        Alpha = alpha;
+        Attributes = attributes;
+    }
+
+    public float[] Height { get; }
+    public byte[] Layer1 { get; }
+    public byte[] Layer2 { get; }
+    public float[] Alpha { get; }
+    public ushort[] Attributes { get; }
+}
+
+public sealed class ObjectInstance
+{
+    public short TypeId { get; set; }
+    public string? TypeName { get; set; }
+    public Vector3 RawPosition { get; set; }
+    public Vector3 Position { get; set; }
+    public Vector3 Rotation { get; set; }
+    public float Scale { get; set; }
+}
+
+public sealed class WorldData
+{
+    public string WorldPath { get; init; } = string.Empty;
+    public string ObjectsPath { get; init; } = string.Empty;
+    public int MapId { get; init; }
+    public int ObjectVersion { get; init; }
+    public TerrainData Terrain { get; init; } = null!;
+    public List<ObjectInstance> Objects { get; init; } = new();
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Gui/MainForm.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Gui/MainForm.cs
@@ -1,0 +1,372 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using TerrenoVisualisado.Core;
+
+namespace TerrenoVisualisado.Gui;
+
+public class MainForm : Form
+{
+    private readonly TextBox _worldPath;
+    private readonly TextBox _objectPath;
+    private readonly TextBox _enumPath;
+    private readonly CheckBox _forceMapId;
+    private readonly NumericUpDown _mapIdNumeric;
+    private readonly CheckBox _customHeightScale;
+    private readonly NumericUpDown _heightScaleNumeric;
+    private readonly CheckBox _forceExtendedHeight;
+    private readonly Button _loadButton;
+    private readonly Button _exportButton;
+    private readonly ComboBox _previewMode;
+    private readonly CheckBox _overlayObjects;
+    private readonly PictureBox _preview;
+    private readonly TextBox _summary;
+    private readonly ListView _objectList;
+
+    private readonly WorldLoader _loader = new();
+    private WorldData? _world;
+
+    public MainForm()
+    {
+        Text = "Terreno Visualisado";
+        MinimumSize = new System.Drawing.Size(960, 720);
+
+        var layout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 2,
+        };
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        Controls.Add(layout);
+
+        var controlPanel = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 14,
+            AutoSize = true,
+        };
+        controlPanel.ColumnStyles.Clear();
+        for (var i = 0; i < controlPanel.ColumnCount; i++)
+        {
+            controlPanel.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+        }
+
+        _worldPath = new TextBox { Width = 280, Anchor = AnchorStyles.Left | AnchorStyles.Right };
+        _objectPath = new TextBox { Width = 200, Anchor = AnchorStyles.Left | AnchorStyles.Right };
+        _enumPath = new TextBox { Width = 200, Anchor = AnchorStyles.Left | AnchorStyles.Right };
+
+        var worldLabel = new Label { Text = "World:", Anchor = AnchorStyles.Left, AutoSize = true };
+        var objectLabel = new Label { Text = "Objetos:", Anchor = AnchorStyles.Left, AutoSize = true };
+        var enumLabel = new Label { Text = "Enum:", Anchor = AnchorStyles.Left, AutoSize = true };
+
+        var browseWorld = new Button { Text = "...", AutoSize = true };
+        browseWorld.Click += (_, _) => BrowseFolder(_worldPath);
+        var browseObjects = new Button { Text = "...", AutoSize = true };
+        browseObjects.Click += (_, _) => BrowseFolder(_objectPath);
+        var browseEnum = new Button { Text = "...", AutoSize = true };
+        browseEnum.Click += (_, _) => BrowseFile(_enumPath, "EnumModelType.eum|*.eum|Todos|*.*");
+
+        _forceMapId = new CheckBox { Text = "Forçar mapa:", AutoSize = true };
+        _mapIdNumeric = new NumericUpDown
+        {
+            Minimum = 0,
+            Maximum = 999,
+            Width = 60,
+            Enabled = false,
+        };
+        _forceMapId.CheckedChanged += (_, _) => _mapIdNumeric.Enabled = _forceMapId.Checked;
+
+        _customHeightScale = new CheckBox { Text = "Altura x", AutoSize = true };
+        _heightScaleNumeric = new NumericUpDown
+        {
+            Minimum = 0,
+            Maximum = 100,
+            DecimalPlaces = 2,
+            Increment = 0.1M,
+            Value = 1.50M,
+            Width = 70,
+            Enabled = false,
+        };
+        _customHeightScale.CheckedChanged += (_, _) => _heightScaleNumeric.Enabled = _customHeightScale.Checked;
+
+        _forceExtendedHeight = new CheckBox { Text = "Forçar TerrainHeightNew", AutoSize = true };
+
+        _loadButton = new Button { Text = "Carregar", AutoSize = true };
+        _loadButton.Click += (_, _) => LoadWorld();
+
+        _exportButton = new Button { Text = "Exportar JSON", AutoSize = true, Enabled = false };
+        _exportButton.Click += (_, _) => ExportJson();
+
+        _previewMode = new ComboBox { DropDownStyle = ComboBoxStyle.DropDownList, Width = 150 };
+        _previewMode.Items.AddRange(new object[]
+        {
+            new PreviewItem("Altura", PreviewMode.Height),
+            new PreviewItem("Layer 1", PreviewMode.Layer1),
+            new PreviewItem("Layer 2", PreviewMode.Layer2),
+            new PreviewItem("Alfa", PreviewMode.Alpha),
+            new PreviewItem("Atributos", PreviewMode.Attributes),
+        });
+        _previewMode.SelectedIndex = 0;
+        _previewMode.SelectedIndexChanged += (_, _) => RenderPreview();
+
+        _overlayObjects = new CheckBox { Text = "Sobrepor objetos", AutoSize = true, Checked = true };
+        _overlayObjects.CheckedChanged += (_, _) => RenderPreview();
+
+        controlPanel.Controls.Add(worldLabel, 0, 0);
+        controlPanel.Controls.Add(_worldPath, 1, 0);
+        controlPanel.Controls.Add(browseWorld, 2, 0);
+        controlPanel.Controls.Add(objectLabel, 3, 0);
+        controlPanel.Controls.Add(_objectPath, 4, 0);
+        controlPanel.Controls.Add(browseObjects, 5, 0);
+        controlPanel.Controls.Add(enumLabel, 6, 0);
+        controlPanel.Controls.Add(_enumPath, 7, 0);
+        controlPanel.Controls.Add(browseEnum, 8, 0);
+        controlPanel.Controls.Add(_forceMapId, 9, 0);
+        controlPanel.Controls.Add(_mapIdNumeric, 10, 0);
+        controlPanel.Controls.Add(_customHeightScale, 11, 0);
+        controlPanel.Controls.Add(_heightScaleNumeric, 12, 0);
+        controlPanel.Controls.Add(_forceExtendedHeight, 13, 0);
+
+        var controlRow2 = new FlowLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            AutoSize = true,
+        };
+        controlRow2.Controls.Add(_previewMode);
+        controlRow2.Controls.Add(_overlayObjects);
+        controlRow2.Controls.Add(_loadButton);
+        controlRow2.Controls.Add(_exportButton);
+
+        layout.Controls.Add(controlPanel, 0, 0);
+        layout.Controls.Add(controlRow2, 0, 1);
+
+        var split = new SplitContainer
+        {
+            Dock = DockStyle.Fill,
+            Orientation = Orientation.Vertical,
+            SplitterDistance = 650,
+        };
+        layout.Controls.Add(split, 0, 2);
+
+        _preview = new PictureBox
+        {
+            Dock = DockStyle.Fill,
+            SizeMode = PictureBoxSizeMode.Zoom,
+            BackColor = System.Drawing.Color.Black,
+        };
+        split.Panel1.Controls.Add(_preview);
+
+        var tabs = new TabControl { Dock = DockStyle.Fill };
+        split.Panel2.Controls.Add(tabs);
+
+        _summary = new TextBox
+        {
+            Dock = DockStyle.Fill,
+            Multiline = true,
+            ReadOnly = true,
+            ScrollBars = ScrollBars.Vertical,
+        };
+        var summaryPage = new TabPage("Resumo") { Padding = new Padding(3) };
+        summaryPage.Controls.Add(_summary);
+
+        _objectList = new ListView
+        {
+            Dock = DockStyle.Fill,
+            View = View.Details,
+            FullRowSelect = true,
+        };
+        _objectList.Columns.Add("Objeto", 180);
+        _objectList.Columns.Add("Quantidade", 90);
+        var objectsPage = new TabPage("Objetos") { Padding = new Padding(3) };
+        objectsPage.Controls.Add(_objectList);
+
+        tabs.TabPages.Add(summaryPage);
+        tabs.TabPages.Add(objectsPage);
+
+        // Adjust layout row styles
+        layout.RowCount = 3;
+        layout.RowStyles[0] = new RowStyle(SizeType.AutoSize);
+        layout.RowStyles[1] = new RowStyle(SizeType.AutoSize);
+        layout.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _preview.Image?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    private void BrowseFolder(TextBox target)
+    {
+        using var dialog = new FolderBrowserDialog();
+        if (dialog.ShowDialog(this) == DialogResult.OK)
+        {
+            target.Text = dialog.SelectedPath;
+        }
+    }
+
+    private void BrowseFile(TextBox target, string filter)
+    {
+        using var dialog = new OpenFileDialog { Filter = filter };
+        if (dialog.ShowDialog(this) == DialogResult.OK)
+        {
+            target.Text = dialog.FileName;
+        }
+    }
+
+    private void LoadWorld()
+    {
+        if (string.IsNullOrWhiteSpace(_worldPath.Text))
+        {
+            MessageBox.Show(this, "Informe o diretório do mundo.", "Terreno Visualisado", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        var options = new WorldLoader.LoadOptions
+        {
+            ObjectRoot = string.IsNullOrWhiteSpace(_objectPath.Text) ? null : _objectPath.Text,
+            EnumPath = string.IsNullOrWhiteSpace(_enumPath.Text) ? null : _enumPath.Text,
+            ForceExtendedHeight = _forceExtendedHeight.Checked,
+            HeightScale = _customHeightScale.Checked ? (float?)Convert.ToDouble(_heightScaleNumeric.Value) : null,
+            MapId = _forceMapId.Checked ? (int?)Convert.ToInt32(_mapIdNumeric.Value) : null,
+        };
+
+        try
+        {
+            Cursor = Cursors.WaitCursor;
+            _world = _loader.Load(_worldPath.Text, options);
+            _exportButton.Enabled = true;
+            UpdateSummary();
+            RenderPreview();
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, ex.Message, "Erro ao carregar", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        finally
+        {
+            Cursor = Cursors.Default;
+        }
+    }
+
+    private void ExportJson()
+    {
+        if (_world is null)
+        {
+            return;
+        }
+
+        using var dialog = new SaveFileDialog
+        {
+            Filter = "JSON|*.json|Todos|*.*",
+            FileName = $"terrainsummary_{_world.MapId}.json",
+        };
+
+        if (dialog.ShowDialog(this) == DialogResult.OK)
+        {
+            try
+            {
+                WorldExporter.WriteJson(_world, dialog.FileName);
+                MessageBox.Show(this, "Exportação concluída!", "Terreno Visualisado", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, ex.Message, "Erro ao exportar", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+    }
+
+    private void UpdateSummary()
+    {
+        if (_world is null)
+        {
+            _summary.Text = string.Empty;
+            _objectList.Items.Clear();
+            return;
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine($"Mapa: {_world.MapId}");
+        builder.AppendLine($"World: {_world.WorldPath}");
+        builder.AppendLine($"Objects: {_world.ObjectsPath}");
+        builder.AppendLine($"Objetos: {_world.Objects.Count} (versão {_world.ObjectVersion})");
+
+        var tileCounts = new Dictionary<byte, int>();
+        for (var i = 0; i < _world.Terrain.Layer1.Length; i++)
+        {
+            var tile1 = _world.Terrain.Layer1[i];
+            var tile2 = _world.Terrain.Layer2[i];
+            tileCounts.TryGetValue(tile1, out var count1);
+            tileCounts[tile1] = count1 + 1;
+            tileCounts.TryGetValue(tile2, out var count2);
+            tileCounts[tile2] = count2 + 1;
+        }
+
+        builder.AppendLine("Tiles mais comuns:");
+        foreach (var pair in tileCounts.OrderByDescending(kv => kv.Value).Take(8))
+        {
+            builder.AppendLine($"  {pair.Key:D3}: {pair.Value}");
+        }
+
+        var attributeCounts = new Dictionary<ushort, int>();
+        foreach (var attr in _world.Terrain.Attributes)
+        {
+            attributeCounts.TryGetValue(attr, out var count);
+            attributeCounts[attr] = count + 1;
+        }
+        builder.AppendLine("Atributos mais comuns:");
+        foreach (var pair in attributeCounts.OrderByDescending(kv => kv.Value).Take(8))
+        {
+            builder.AppendLine($"  0x{pair.Key:X3}: {pair.Value}");
+        }
+
+        _summary.Text = builder.ToString();
+
+        var objectCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var obj in _world.Objects)
+        {
+            var key = obj.TypeName ?? $"ID_{obj.TypeId}";
+            objectCounts.TryGetValue(key, out var count);
+            objectCounts[key] = count + 1;
+        }
+
+        _objectList.BeginUpdate();
+        _objectList.Items.Clear();
+        foreach (var pair in objectCounts.OrderByDescending(kv => kv.Value))
+        {
+            var item = new ListViewItem(pair.Key) { SubItems = { pair.Value.ToString()! } };
+            _objectList.Items.Add(item);
+        }
+        _objectList.EndUpdate();
+    }
+
+    private void RenderPreview()
+    {
+        if (_world is null)
+        {
+            _preview.Image?.Dispose();
+            _preview.Image = null;
+            return;
+        }
+
+        if (_previewMode.SelectedItem is not PreviewItem item)
+        {
+            return;
+        }
+
+        _preview.Image?.Dispose();
+        _preview.Image = TerrainPreviewRenderer.Render(_world, item.Mode, _overlayObjects.Checked);
+    }
+
+    private sealed record PreviewItem(string Text, PreviewMode Mode)
+    {
+        public override string ToString() => Text;
+    }
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Gui/Program.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Gui/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Windows.Forms;
+
+namespace TerrenoVisualisado.Gui;
+
+internal static class Program
+{
+    [STAThread]
+    private static void Main()
+    {
+        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+        Application.Run(new MainForm());
+    }
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Gui/TerrainPreviewRenderer.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Gui/TerrainPreviewRenderer.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using TerrenoVisualisado.Core;
+
+namespace TerrenoVisualisado.Gui;
+
+internal enum PreviewMode
+{
+    Height,
+    Layer1,
+    Layer2,
+    Alpha,
+    Attributes,
+}
+
+internal static class TerrainPreviewRenderer
+{
+    public static Bitmap Render(WorldData world, PreviewMode mode, bool overlayObjects)
+    {
+        var size = WorldLoader.TerrainSize;
+        var bitmap = new Bitmap(size, size, PixelFormat.Format32bppArgb);
+        var rect = new Rectangle(0, 0, size, size);
+        var data = bitmap.LockBits(rect, ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
+        try
+        {
+            var stride = data.Stride;
+            var buffer = new byte[stride * size];
+            switch (mode)
+            {
+                case PreviewMode.Height:
+                    RenderHeight(world.Terrain.Height, buffer, stride, size);
+                    break;
+                case PreviewMode.Layer1:
+                    RenderTileLayer(world.Terrain.Layer1, buffer, stride, size);
+                    break;
+                case PreviewMode.Layer2:
+                    RenderTileLayer(world.Terrain.Layer2, buffer, stride, size);
+                    break;
+                case PreviewMode.Alpha:
+                    RenderAlpha(world.Terrain.Alpha, buffer, stride, size);
+                    break;
+                case PreviewMode.Attributes:
+                    RenderAttributes(world.Terrain.Attributes, buffer, stride, size);
+                    break;
+            }
+
+            Marshal.Copy(buffer, 0, data.Scan0, buffer.Length);
+        }
+        finally
+        {
+            bitmap.UnlockBits(data);
+        }
+
+        if (overlayObjects)
+        {
+            using var g = Graphics.FromImage(bitmap);
+            using var brush = new SolidBrush(Color.FromArgb(192, Color.Red));
+            foreach (var obj in world.Objects)
+            {
+                var px = obj.RawPosition.X / 100f;
+                var py = obj.RawPosition.Y / 100f;
+                var x = Math.Clamp((int)MathF.Round(px), 0, size - 1);
+                var y = Math.Clamp((int)MathF.Round(py), 0, size - 1);
+                var screenY = size - 1 - y;
+                g.FillEllipse(brush, x - 2, screenY - 2, 4, 4);
+            }
+        }
+
+        return bitmap;
+    }
+
+    private static void RenderHeight(float[] height, byte[] buffer, int stride, int size)
+    {
+        var min = float.MaxValue;
+        var max = float.MinValue;
+        foreach (var value in height)
+        {
+            if (!float.IsFinite(value))
+            {
+                continue;
+            }
+            if (value < min) min = value;
+            if (value > max) max = value;
+        }
+
+        if (min > max)
+        {
+            min = 0;
+            max = 1;
+        }
+
+        var range = Math.Max(max - min, 0.01f);
+        for (var y = 0; y < size; y++)
+        {
+            var row = buffer.AsSpan(y * stride, stride);
+            for (var x = 0; x < size; x++)
+            {
+                var index = y * size + x;
+                var value = height[index];
+                if (!float.IsFinite(value))
+                {
+                    value = min;
+                }
+                var t = (value - min) / range;
+                var color = SampleHeightGradient(t);
+                var offset = x * 4;
+                row[offset + 0] = color.B;
+                row[offset + 1] = color.G;
+                row[offset + 2] = color.R;
+                row[offset + 3] = 255;
+            }
+        }
+    }
+
+    private static void RenderTileLayer(byte[] data, byte[] buffer, int stride, int size)
+    {
+        for (var y = 0; y < size; y++)
+        {
+            var row = buffer.AsSpan(y * stride, stride);
+            for (var x = 0; x < size; x++)
+            {
+                var value = data[y * size + x];
+                var color = ColorFromTile(value);
+                var offset = x * 4;
+                row[offset + 0] = color.B;
+                row[offset + 1] = color.G;
+                row[offset + 2] = color.R;
+                row[offset + 3] = 255;
+            }
+        }
+    }
+
+    private static void RenderAlpha(float[] alpha, byte[] buffer, int stride, int size)
+    {
+        for (var y = 0; y < size; y++)
+        {
+            var row = buffer.AsSpan(y * stride, stride);
+            for (var x = 0; x < size; x++)
+            {
+                var value = alpha[y * size + x];
+                var clamped = (byte)Math.Clamp((int)MathF.Round(value * 255f), 0, 255);
+                var offset = x * 4;
+                row[offset + 0] = clamped;
+                row[offset + 1] = clamped;
+                row[offset + 2] = clamped;
+                row[offset + 3] = 255;
+            }
+        }
+    }
+
+    private static void RenderAttributes(ushort[] attributes, byte[] buffer, int stride, int size)
+    {
+        for (var y = 0; y < size; y++)
+        {
+            var row = buffer.AsSpan(y * stride, stride);
+            for (var x = 0; x < size; x++)
+            {
+                var value = attributes[y * size + x];
+                var color = ColorFromAttribute(value);
+                var offset = x * 4;
+                row[offset + 0] = color.B;
+                row[offset + 1] = color.G;
+                row[offset + 2] = color.R;
+                row[offset + 3] = 255;
+            }
+        }
+    }
+
+    private static Color SampleHeightGradient(float t)
+    {
+        t = Math.Clamp(t, 0f, 1f);
+        if (t < 0.33f)
+        {
+            return Lerp(Color.DarkBlue, Color.CornflowerBlue, t / 0.33f);
+        }
+        if (t < 0.66f)
+        {
+            return Lerp(Color.ForestGreen, Color.YellowGreen, (t - 0.33f) / 0.33f);
+        }
+        return Lerp(Color.SaddleBrown, Color.WhiteSmoke, (t - 0.66f) / 0.34f);
+    }
+
+    private static Color ColorFromTile(byte value)
+    {
+        var hue = (value / 255f) * 360f;
+        return ColorFromHsv(hue, 0.6f, 0.9f);
+    }
+
+    private static Color ColorFromAttribute(ushort value)
+    {
+        var hue = ((value * 37) % 360);
+        var saturation = 0.5f + ((value % 5) * 0.1f);
+        return ColorFromHsv(hue, Math.Clamp(saturation, 0f, 1f), 0.85f);
+    }
+
+    private static Color Lerp(Color a, Color b, float t)
+    {
+        t = Math.Clamp(t, 0f, 1f);
+        var r = (byte)(a.R + (b.R - a.R) * t);
+        var g = (byte)(a.G + (b.G - a.G) * t);
+        var bCh = (byte)(a.B + (b.B - a.B) * t);
+        return Color.FromArgb(r, g, bCh);
+    }
+
+    private static Color ColorFromHsv(double hue, double saturation, double value)
+    {
+        saturation = Math.Clamp(saturation, 0.0, 1.0);
+        value = Math.Clamp(value, 0.0, 1.0);
+        var c = value * saturation;
+        var x = c * (1 - Math.Abs((hue / 60.0 % 2) - 1));
+        var m = value - c;
+
+        double r = 0, g = 0, b = 0;
+        if (hue < 60)
+        {
+            r = c; g = x; b = 0;
+        }
+        else if (hue < 120)
+        {
+            r = x; g = c; b = 0;
+        }
+        else if (hue < 180)
+        {
+            r = 0; g = c; b = x;
+        }
+        else if (hue < 240)
+        {
+            r = 0; g = x; b = c;
+        }
+        else if (hue < 300)
+        {
+            r = x; g = 0; b = c;
+        }
+        else
+        {
+            r = c; g = 0; b = x;
+        }
+
+        var red = (byte)Math.Clamp((r + m) * 255.0, 0, 255);
+        var green = (byte)Math.Clamp((g + m) * 255.0, 0, 255);
+        var blue = (byte)Math.Clamp((b + m) * 255.0, 0, 255);
+        return Color.FromArgb(red, green, blue);
+    }
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Gui/TerrenoVisualisado.Gui.csproj
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Gui/TerrenoVisualisado.Gui.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../TerrenoVisualisado.Core/TerrenoVisualisado.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/terreno_visualisado/TerrenoVisualisado.csproj
+++ b/tools/terreno_visualisado/TerrenoVisualisado.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TerrenoVisualisado.Core/TerrenoVisualisado.Core.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- move the world loading and export routines into a shared TerrenoVisualisado.Core library
- update the CLI to reuse the shared exporter and keep the original summaries intact
- add a WinForms GUI that previews terrain layers, overlays objects, and reuses the JSON export
- document how to build the new GUI project alongside the console tool

## Testing
- dotnet build tools/terreno_visualisado/TerrenoVisualisado.csproj -c Release *(fails: dotnet CLI not available in container)*
- dotnet build tools/terreno_visualisado/TerrenoVisualisado.Gui/TerrenoVisualisado.Gui.csproj -c Release *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e6d497388332880b520221b02f6b