### PR TITLE
Add full art pipeline to terrain_visualisado

### DIFF
--- a/tools/terreno_visualisado/Program.cs
+++ b/tools/terreno_visualisado/Program.cs
@@ -83,6 +83,16 @@ internal static class Program
             Console.WriteLine($"  {name}: {count}");
         }
 
+        if (world.Visual is { } visual)
+        {
+            Console.WriteLine($"Texturas distintas: {visual.TileTextures.Count} (faltando {visual.MissingTileIndices.Count})");
+            var waterTiles = visual.MaterialFlagsPerTile.Count(flag => (flag & (uint)MaterialFlags.Water) != 0);
+            var lavaTiles = visual.MaterialFlagsPerTile.Count(flag => (flag & (uint)MaterialFlags.Lava) != 0);
+            Console.WriteLine($"Tiles com água: {waterTiles}, lava: {lavaTiles}");
+        }
+
+        Console.WriteLine($"Modelos BMD carregados: {world.ModelLibrary.Models.Count} (falhas: {world.ModelLibrary.Failures.Count})");
+
         void Increment(byte tile)
         {
             tileCounts.TryGetValue(tile, out var count);

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/BmdResources.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/BmdResources.cs
@@ -1,0 +1,394 @@
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Numerics;
+using System.Text;
+
+namespace TerrenoVisualisado.Core;
+
+public sealed class BmdMesh
+{
+    public string Name { get; init; } = string.Empty;
+    public float[] Positions { get; init; } = Array.Empty<float>();
+    public float[] Normals { get; init; } = Array.Empty<float>();
+    public float[] TexCoords { get; init; } = Array.Empty<float>();
+    public uint[] Indices { get; init; } = Array.Empty<uint>();
+    public string TextureName { get; init; } = string.Empty;
+    public MaterialFlags MaterialFlags { get; init; }
+}
+
+public sealed class BmdModel
+{
+    public string Name { get; init; } = string.Empty;
+    public int Version { get; init; }
+    public IReadOnlyList<BmdMesh> Meshes { get; init; } = Array.Empty<BmdMesh>();
+    public string SourcePath { get; init; } = string.Empty;
+}
+
+public sealed class BmdLibrary
+{
+    private readonly Dictionary<string, List<string>> _index = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, BmdModel> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _failures = new(StringComparer.OrdinalIgnoreCase);
+    private readonly MaterialStateLibrary _materials;
+
+    public BmdLibrary(IEnumerable<string> searchRoots, MaterialStateLibrary materials)
+    {
+        _materials = materials;
+        BuildIndex(searchRoots);
+    }
+
+    public IReadOnlyDictionary<string, string> Failures => _failures;
+
+    public BmdModel? Load(ObjectInstance obj)
+    {
+        var path = Resolve(obj);
+        if (path is null)
+        {
+            return null;
+        }
+        if (_cache.TryGetValue(path, out var cached))
+        {
+            return cached;
+        }
+        try
+        {
+            var model = BmdLoader.Load(path, _materials);
+            _cache[path] = model;
+            return model;
+        }
+        catch (Exception ex)
+        {
+            _failures[path] = ex.Message;
+            return null;
+        }
+    }
+
+    public string? Resolve(ObjectInstance obj)
+    {
+        foreach (var key in EnumerateCandidates(obj))
+        {
+            if (_index.TryGetValue(key, out var paths))
+            {
+                foreach (var path in paths)
+                {
+                    if (File.Exists(path))
+                    {
+                        return path;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private IEnumerable<string> EnumerateCandidates(ObjectInstance obj)
+    {
+        if (!string.IsNullOrEmpty(obj.TypeName))
+        {
+            var lowered = obj.TypeName.ToLowerInvariant();
+            yield return lowered;
+            if (lowered.StartsWith("model_", StringComparison.OrdinalIgnoreCase))
+            {
+                var trimmed = lowered[6..];
+                yield return trimmed;
+                yield return trimmed.Replace("_", string.Empty, StringComparison.Ordinal);
+            }
+            yield return lowered.Replace("_", string.Empty, StringComparison.Ordinal);
+        }
+        yield return obj.TypeId.ToString(CultureInfo.InvariantCulture);
+        yield return $"object{obj.TypeId}";
+        yield return $"object{obj.TypeId:00}";
+    }
+
+    private void BuildIndex(IEnumerable<string> searchRoots)
+    {
+        var unique = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var root in searchRoots)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+            {
+                continue;
+            }
+            var full = Path.GetFullPath(root);
+            if (!Directory.Exists(full) || !unique.Add(full))
+            {
+                continue;
+            }
+            foreach (var file in Directory.EnumerateFiles(full, "*.bmd", SearchOption.AllDirectories))
+            {
+                var name = Path.GetFileNameWithoutExtension(file).ToLowerInvariant();
+                AddIndex(name, file);
+                AddIndex(Path.GetFileName(file).ToLowerInvariant(), file);
+                var relative = Path.GetRelativePath(full, file).Replace('\\', '/').ToLowerInvariant();
+                AddIndex(relative, file);
+                var parent = Path.GetFileName(Path.GetDirectoryName(file) ?? string.Empty).ToLowerInvariant();
+                if (parent.StartsWith("object", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddIndex(parent + "_" + name, file);
+                    var digits = new string(name.Where(char.IsDigit).ToArray());
+                    if (!string.IsNullOrEmpty(digits))
+                    {
+                        AddIndex(parent + "_" + digits, file);
+                        AddIndex(digits, file);
+                    }
+                }
+            }
+        }
+    }
+
+    private void AddIndex(string key, string path)
+    {
+        if (!_index.TryGetValue(key, out var list))
+        {
+            list = new List<string>();
+            _index[key] = list;
+        }
+        if (!list.Contains(path, StringComparer.OrdinalIgnoreCase))
+        {
+            list.Add(path);
+        }
+    }
+}
+
+internal static class BmdLoader
+{
+    public static BmdModel Load(string path, MaterialStateLibrary materials)
+    {
+        var raw = File.ReadAllBytes(path);
+        if (raw.Length < 7 || raw[0] != 'B' || raw[1] != 'M' || raw[2] != 'D')
+        {
+            throw new InvalidDataException($"Arquivo BMD inválido: {path}");
+        }
+
+        var data = raw;
+        var ptr = 3;
+        byte version = data[ptr++];
+        if (version == 12)
+        {
+            if (ptr + 4 > data.Length)
+            {
+                throw new InvalidDataException("Cabeçalho BMD truncado");
+            }
+            var size = BinaryPrimitives.ReadInt32LittleEndian(data.AsSpan(ptr));
+            ptr += 4;
+            if (ptr + size > data.Length)
+            {
+                throw new InvalidDataException("Bloco criptografado incompleto");
+            }
+            data = MapCrypto.Decrypt(data.AsSpan(ptr, size));
+            ptr = 0;
+            version = data[ptr++];
+        }
+
+        var name = ReadCString(data, ref ptr, 32);
+        if (ptr + 6 > data.Length)
+        {
+            throw new InvalidDataException("BMD incompleto");
+        }
+        var numMesh = BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(ptr)); ptr += 2;
+        var numBones = BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(ptr)); ptr += 2;
+        var numActions = BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(ptr)); ptr += 2;
+
+        var meshes = new List<BmdMesh>();
+        for (var meshIndex = 0; meshIndex < numMesh; meshIndex++)
+        {
+            if (ptr + 10 > data.Length)
+            {
+                throw new InvalidDataException("Cabeçalho de malha truncado");
+            }
+            var numVertices = BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(ptr)); ptr += 2;
+            var numNormals = BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(ptr)); ptr += 2;
+            var numTexCoords = BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(ptr)); ptr += 2;
+            var numTriangles = BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(ptr)); ptr += 2;
+            ptr += 2; // texture index (não utilizado)
+
+            var vertices = new Vector3[numVertices];
+            var vertexBones = new short[numVertices];
+            for (var i = 0; i < numVertices; i++)
+            {
+                if (ptr + 16 > data.Length)
+                {
+                    throw new InvalidDataException("Dados de vértice truncados");
+                }
+                var node = BinaryPrimitives.ReadInt16LittleEndian(data.AsSpan(ptr));
+                ptr += 2;
+                ptr += 2; // padding
+                var x = BinaryPrimitives.ReadSingleLittleEndian(data.AsSpan(ptr)); ptr += 4;
+                var y = BinaryPrimitives.ReadSingleLittleEndian(data.AsSpan(ptr)); ptr += 4;
+                var z = BinaryPrimitives.ReadSingleLittleEndian(data.AsSpan(ptr)); ptr += 4;
+                vertexBones[i] = node;
+                vertices[i] = new Vector3(x, y, z);
+            }
+
+            for (var i = 0; i < numNormals; i++)
+            {
+                ptr += 18; // ignorar normais originais
+            }
+
+            var texCoords = new Vector2[numTexCoords];
+            for (var i = 0; i < numTexCoords; i++)
+            {
+                if (ptr + 8 > data.Length)
+                {
+                    throw new InvalidDataException("Coordenadas UV truncadas");
+                }
+                var u = BinaryPrimitives.ReadSingleLittleEndian(data.AsSpan(ptr)); ptr += 4;
+                var v = BinaryPrimitives.ReadSingleLittleEndian(data.AsSpan(ptr)); ptr += 4;
+                texCoords[i] = new Vector2(u, 1.0f - v);
+            }
+
+            var triangles = new List<(int polygon, short[] vertexIdx, short[] texIdx)>();
+            for (var i = 0; i < numTriangles; i++)
+            {
+                if (ptr + 32 > data.Length)
+                {
+                    throw new InvalidDataException("Triângulos truncados");
+                }
+                var polygon = (sbyte)data[ptr++];
+                var vertexIdx = new short[4];
+                var texIdx = new short[4];
+                for (var j = 0; j < 4; j++)
+                {
+                    vertexIdx[j] = BinaryPrimitives.ReadInt16LittleEndian(data.AsSpan(ptr)); ptr += 2;
+                }
+                ptr += 8; // padding
+                for (var j = 0; j < 4; j++)
+                {
+                    texIdx[j] = BinaryPrimitives.ReadInt16LittleEndian(data.AsSpan(ptr)); ptr += 2;
+                }
+                ptr += 8; // padding
+                triangles.Add((polygon, vertexIdx, texIdx));
+            }
+
+            var textureName = ReadCString(data, ref ptr, 32);
+            var meshVertices = new List<Vector3>();
+            var meshNormals = new List<Vector3>();
+            var meshUvs = new List<Vector2>();
+            var meshIndices = new List<uint>();
+
+            void AppendTriangle((int polygon, short[] vertexIdx, short[] texIdx) triangle, ReadOnlySpan<int> order)
+            {
+                var pts = new (Vector3 Position, Vector2 UV, int Bone) [order.Length];
+                for (var k = 0; k < order.Length; k++)
+                {
+                    var vid = triangle.vertexIdx[order[k]];
+                    var tid = triangle.texIdx[order[k]];
+                    var position = SafeFetch(vertices, vid);
+                    var uv = SafeFetch(texCoords, tid);
+                    var bone = SafeFetch(vertexBones, vid);
+                    pts[k] = (position, uv, bone);
+                }
+                var v0 = pts[0].Position;
+                var v1 = pts[1].Position;
+                var v2 = pts[2].Position;
+                var normal = Vector3.Normalize(Vector3.Cross(v1 - v0, v2 - v0));
+                if (!float.IsFinite(normal.X))
+                {
+                    normal = Vector3.UnitY;
+                }
+                foreach (var pt in pts)
+                {
+                    meshVertices.Add(pt.Position);
+                    meshUvs.Add(pt.UV);
+                    meshNormals.Add(normal);
+                    meshIndices.Add((uint)(meshVertices.Count - 1));
+                }
+            }
+
+            for (var currentTriangle = 0; currentTriangle < triangles.Count; currentTriangle++)
+            {
+                var triangle = triangles[currentTriangle];
+                var polygon = triangle.polygon;
+                if (polygon == 4)
+                {
+                    AppendTriangle(triangle, stackalloc int[] { 0, 1, 2 });
+                    AppendTriangle(triangle, stackalloc int[] { 0, 2, 3 });
+                }
+                else
+                {
+                    AppendTriangle(triangle, stackalloc int[] { 0, 1, 2 });
+                }
+            }
+
+            var mesh = new BmdMesh
+            {
+                Name = string.IsNullOrEmpty(textureName) ? $"mesh{meshIndex}" : textureName,
+                Positions = Flatten(meshVertices),
+                Normals = Flatten(meshNormals),
+                TexCoords = Flatten(meshUvs),
+                Indices = meshIndices.ToArray(),
+                TextureName = textureName,
+                MaterialFlags = materials.Lookup(textureName).ToFlags(),
+            };
+            meshes.Add(mesh);
+        }
+
+        return new BmdModel
+        {
+            Name = string.IsNullOrEmpty(name) ? Path.GetFileNameWithoutExtension(path) : name,
+            Version = version,
+            Meshes = meshes,
+            SourcePath = path,
+        };
+    }
+
+    private static Vector3 SafeFetch(Vector3[] array, int index)
+    {
+        if (index >= 0 && index < array.Length)
+        {
+            return array[index];
+        }
+        return Vector3.Zero;
+    }
+
+    private static Vector2 SafeFetch(Vector2[] array, int index)
+    {
+        if (index >= 0 && index < array.Length)
+        {
+            return array[index];
+        }
+        return Vector2.Zero;
+    }
+
+    private static int SafeFetch(short[] array, int index)
+    {
+        if (index >= 0 && index < array.Length)
+        {
+            return array[index];
+        }
+        return -1;
+    }
+
+    private static float[] Flatten(List<Vector3> values)
+    {
+        var result = new float[values.Count * 3];
+        for (var i = 0; i < values.Count; i++)
+        {
+            result[i * 3 + 0] = values[i].X;
+            result[i * 3 + 1] = values[i].Y;
+            result[i * 3 + 2] = values[i].Z;
+        }
+        return result;
+    }
+
+    private static float[] Flatten(List<Vector2> values)
+    {
+        var result = new float[values.Count * 2];
+        for (var i = 0; i < values.Count; i++)
+        {
+            result[i * 2 + 0] = values[i].X;
+            result[i * 2 + 1] = values[i].Y;
+        }
+        return result;
+    }
+
+    private static string ReadCString(byte[] data, ref int offset, int length)
+    {
+        var span = data.AsSpan(offset, Math.Min(length, data.Length - offset));
+        var zero = span.IndexOf((byte)0);
+        var actualLength = zero >= 0 ? zero : span.Length;
+        var text = Encoding.GetEncoding(1252).GetString(span[..actualLength]);
+        offset += length;
+        return text.Trim();
+    }
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/MapCrypto.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/MapCrypto.cs
@@ -1,0 +1,24 @@
+namespace TerrenoVisualisado.Core;
+
+internal static class MapCrypto
+{
+    private static readonly byte[] XorKey =
+    {
+        0xD1, 0x73, 0x52, 0xF6, 0xD2, 0x9A, 0xCB, 0x27,
+        0x3E, 0xAF, 0x59, 0x31, 0x37, 0xB3, 0xE7, 0xA2,
+    };
+
+    public static byte[] Decrypt(ReadOnlySpan<byte> input)
+    {
+        var output = new byte[input.Length];
+        byte wMapKey = 0x5E;
+        for (var i = 0; i < input.Length; i++)
+        {
+            var value = input[i];
+            var decrypted = (byte)(((value ^ XorKey[i % XorKey.Length]) - wMapKey) & 0xFF);
+            output[i] = decrypted;
+            wMapKey = (byte)((value + 0x3D) & 0xFF);
+        }
+        return output;
+    }
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/MaterialFlags.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/MaterialFlags.cs
@@ -1,0 +1,16 @@
+namespace TerrenoVisualisado.Core;
+
+[System.Flags]
+public enum MaterialFlags : uint
+{
+    None = 0,
+    Water = 1u << 0,
+    Lava = 1u << 1,
+    Transparent = 1u << 2,
+    Additive = 1u << 3,
+    Emissive = 1u << 4,
+    AlphaTest = 1u << 5,
+    DoubleSided = 1u << 6,
+    NoShadow = 1u << 7,
+    NormalMap = 1u << 8,
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/MaterialState.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/MaterialState.cs
@@ -1,0 +1,555 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace TerrenoVisualisado.Core;
+
+public sealed record MaterialState
+{
+    public string Name { get; init; } = string.Empty;
+    public string SrcBlend { get; init; } = "one";
+    public string DstBlend { get; init; } = "zero";
+    public string BlendOp { get; init; } = "add";
+    public bool AlphaTest { get; init; }
+    public string AlphaFunc { get; init; } = "always";
+    public float AlphaRef { get; init; }
+    public bool DepthWrite { get; init; } = true;
+    public bool DepthTest { get; init; } = true;
+    public string CullMode { get; init; } = "back";
+    public (float R, float G, float B) Emissive { get; init; } = (0f, 0f, 0f);
+    public (float R, float G, float B) Specular { get; init; } = (0.2f, 0.2f, 0.2f);
+    public float SpecularPower { get; init; } = 16f;
+    public bool DoubleSided { get; init; }
+    public bool Additive { get; init; }
+    public bool Transparent { get; init; }
+    public bool Water { get; init; }
+    public bool Lava { get; init; }
+    public string? NormalMap { get; init; }
+    public bool ReceiveShadows { get; init; } = true;
+
+    public MaterialFlags ToFlags()
+    {
+        var flags = MaterialFlags.None;
+        if (Water)
+        {
+            flags |= MaterialFlags.Water | MaterialFlags.Transparent;
+        }
+        if (Lava)
+        {
+            flags |= MaterialFlags.Lava | MaterialFlags.Transparent;
+        }
+        if (Transparent)
+        {
+            flags |= MaterialFlags.Transparent;
+        }
+        if (Additive)
+        {
+            flags |= MaterialFlags.Additive;
+        }
+        if (MathF.Sqrt(Emissive.R * Emissive.R + Emissive.G * Emissive.G + Emissive.B * Emissive.B) > 1e-3f)
+        {
+            flags |= MaterialFlags.Emissive;
+        }
+        if (AlphaTest)
+        {
+            flags |= MaterialFlags.AlphaTest;
+        }
+        if (DoubleSided || string.Equals(CullMode, "none", StringComparison.OrdinalIgnoreCase))
+        {
+            flags |= MaterialFlags.DoubleSided;
+        }
+        if (!ReceiveShadows)
+        {
+            flags |= MaterialFlags.NoShadow;
+        }
+        if (!string.IsNullOrEmpty(NormalMap))
+        {
+            flags |= MaterialFlags.NormalMap;
+        }
+        return flags;
+    }
+}
+
+public sealed class MaterialStateLibrary
+{
+    private static readonly string[] CandidateFiles =
+    {
+        "materials.json",
+        "material_table.json",
+        "material_table.txt",
+        "material_table.csv",
+        "materialstate.json",
+        "materialstate.txt",
+    };
+
+    private readonly Dictionary<string, MaterialState> _states = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _aliases = new(StringComparer.OrdinalIgnoreCase);
+
+    public MaterialStateLibrary(string? worldDirectory, IEnumerable<string>? extraRoots = null)
+    {
+        var roots = new List<string>();
+        void Add(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+            var full = Path.GetFullPath(path);
+            if (Directory.Exists(full) && !roots.Contains(full, StringComparer.OrdinalIgnoreCase))
+            {
+                roots.Add(full);
+            }
+        }
+
+        Add(worldDirectory);
+        if (worldDirectory != null)
+        {
+            var parent = Directory.GetParent(worldDirectory);
+            if (parent != null)
+            {
+                Add(Path.Combine(parent.FullName, "Texture"));
+            }
+        }
+        if (extraRoots != null)
+        {
+            foreach (var root in extraRoots)
+            {
+                Add(root);
+            }
+        }
+
+        foreach (var root in roots)
+        {
+            foreach (var candidate in CandidateFiles)
+            {
+                var file = Path.Combine(root, candidate);
+                if (!File.Exists(file))
+                {
+                    continue;
+                }
+                try
+                {
+                    LoadTable(file);
+                }
+                catch
+                {
+                    // ignore malformed tables
+                }
+            }
+        }
+    }
+
+    public MaterialState Lookup(string textureName)
+    {
+        if (string.IsNullOrWhiteSpace(textureName))
+        {
+            return BuildFallback(textureName);
+        }
+
+        var normalized = NormalizeKey(textureName);
+        if (_states.TryGetValue(normalized, out var state))
+        {
+            return state;
+        }
+
+        var stem = Path.GetFileNameWithoutExtension(normalized);
+        if (!string.IsNullOrEmpty(stem) && _states.TryGetValue(stem, out state))
+        {
+            return state;
+        }
+
+        if (_aliases.TryGetValue(normalized, out var alias) && _states.TryGetValue(alias, out state))
+        {
+            return state;
+        }
+
+        return BuildFallback(textureName);
+    }
+
+    private void LoadTable(string path)
+    {
+        var extension = Path.GetExtension(path);
+        if (string.Equals(extension, ".json", StringComparison.OrdinalIgnoreCase))
+        {
+            LoadJson(path);
+        }
+        else if (string.Equals(extension, ".csv", StringComparison.OrdinalIgnoreCase))
+        {
+            LoadCsv(path);
+        }
+        else
+        {
+            LoadText(path);
+        }
+    }
+
+    private void LoadJson(string path)
+    {
+        using var stream = File.OpenRead(path);
+        var node = JsonNode.Parse(stream);
+        if (node is JsonObject obj)
+        {
+            foreach (var (key, value) in obj)
+            {
+                if (value is JsonObject nested)
+                {
+                    StoreEntry(key, nested);
+                }
+            }
+        }
+        else if (node is JsonArray array)
+        {
+            foreach (var element in array)
+            {
+                if (element is JsonObject nested && nested.TryGetPropertyValue("name", out var nameNode) && nameNode is JsonValue nameValue && nameValue.TryGetValue<string>(out var name))
+                {
+                    StoreEntry(name, nested);
+                }
+            }
+        }
+    }
+
+    private void LoadCsv(string path)
+    {
+        using var reader = new StreamReader(path);
+        var header = reader.ReadLine();
+        if (header is null)
+        {
+            return;
+        }
+        var columns = header.Split(',');
+        int IndexOf(string column)
+        {
+            for (var i = 0; i < columns.Length; i++)
+            {
+                if (string.Equals(columns[i].Trim(), column, StringComparison.OrdinalIgnoreCase))
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        var nameIndex = IndexOf("name");
+        if (nameIndex < 0)
+        {
+            nameIndex = IndexOf("texture");
+        }
+        if (nameIndex < 0)
+        {
+            return;
+        }
+
+        string? ReadValue(string[] parts, string column)
+        {
+            var idx = IndexOf(column);
+            if (idx >= 0 && idx < parts.Length)
+            {
+                return parts[idx].Trim();
+            }
+            return null;
+        }
+
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+            var parts = line.Split(',');
+            if (nameIndex >= parts.Length)
+            {
+                continue;
+            }
+            var name = parts[nameIndex].Trim();
+            if (string.IsNullOrEmpty(name))
+            {
+                continue;
+            }
+
+            var payload = new Dictionary<string, object?>
+            {
+                ["src_blend"] = ReadValue(parts, "src_blend"),
+                ["dst_blend"] = ReadValue(parts, "dst_blend"),
+                ["alpha_test"] = ReadValue(parts, "alpha_test"),
+                ["alpha_ref"] = ReadValue(parts, "alpha_ref"),
+                ["depth_write"] = ReadValue(parts, "depth_write"),
+                ["depth_test"] = ReadValue(parts, "depth_test"),
+                ["cull_mode"] = ReadValue(parts, "cull_mode"),
+                ["additive"] = ReadValue(parts, "additive"),
+                ["transparent"] = ReadValue(parts, "transparent"),
+                ["water"] = ReadValue(parts, "water"),
+                ["lava"] = ReadValue(parts, "lava"),
+            };
+            StoreEntry(name, payload);
+        }
+    }
+
+    private void LoadText(string path)
+    {
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            var line = rawLine.Trim();
+            if (string.IsNullOrEmpty(line) || line.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (line.Contains(':'))
+            {
+                var parts = line.Split(':', 2);
+                if (parts.Length == 2)
+                {
+                    StoreEntry(parts[0].Trim(), new Dictionary<string, object?> { ["params"] = parts[1].Trim() });
+                }
+                continue;
+            }
+
+            var tokens = line.Split(',');
+            if (tokens.Length == 0)
+            {
+                continue;
+            }
+
+            var name = tokens[0].Trim();
+            if (string.IsNullOrEmpty(name))
+            {
+                continue;
+            }
+
+            var payload = new Dictionary<string, object?>
+            {
+                ["src_blend"] = tokens.Length > 1 ? tokens[1].Trim() : null,
+                ["dst_blend"] = tokens.Length > 2 ? tokens[2].Trim() : null,
+                ["alpha_test"] = tokens.Length > 3 ? tokens[3].Trim() : null,
+                ["alpha_ref"] = tokens.Length > 4 ? tokens[4].Trim() : null,
+                ["depth_write"] = tokens.Length > 5 ? tokens[5].Trim() : null,
+                ["depth_test"] = tokens.Length > 6 ? tokens[6].Trim() : null,
+                ["cull_mode"] = tokens.Length > 7 ? tokens[7].Trim() : null,
+            };
+            StoreEntry(name, payload);
+        }
+    }
+
+    private void StoreEntry(string name, IReadOnlyDictionary<string, object?> payload)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return;
+        }
+
+        var state = new MaterialState
+        {
+            Name = NormalizeKey(name),
+            SrcBlend = payload.TryGetValue("src_blend", out var src) ? SafeString(src, "one") : "one",
+            DstBlend = payload.TryGetValue("dst_blend", out var dst) ? SafeString(dst, "zero") : "zero",
+            BlendOp = payload.TryGetValue("blend_op", out var op) ? SafeString(op, "add") : "add",
+            AlphaTest = ParseBool(payload.TryGetValue("alpha_test", out var alphaTest) ? alphaTest : null),
+            AlphaFunc = payload.TryGetValue("alpha_func", out var alphaFunc) ? SafeString(alphaFunc, "greater") : "greater",
+            AlphaRef = ParseFloat(payload.TryGetValue("alpha_ref", out var alphaRef) ? alphaRef : null),
+            DepthWrite = ParseBool(payload.TryGetValue("depth_write", out var depthWrite) ? depthWrite : null, true),
+            DepthTest = ParseBool(payload.TryGetValue("depth_test", out var depthTest) ? depthTest : null, true),
+            CullMode = payload.TryGetValue("cull_mode", out var cull) ? SafeString(cull, "back") : "back",
+            Emissive = ParseVec3(payload.TryGetValue("emissive", out var emissive) ? emissive : null),
+            Specular = ParseVec3(payload.TryGetValue("specular", out var specular) ? specular : null),
+            SpecularPower = ParseFloat(payload.TryGetValue("specular_power", out var power) ? power : null, 16f),
+            DoubleSided = ParseBool(payload.TryGetValue("double_sided", out var doubleSided) ? doubleSided : null),
+            Additive = ParseBool(payload.TryGetValue("additive", out var additive) ? additive : null),
+            Transparent = ParseBool(payload.TryGetValue("transparent", out var transparent) ? transparent : null),
+            Water = ParseBool(payload.TryGetValue("water", out var water) ? water : null),
+            Lava = ParseBool(payload.TryGetValue("lava", out var lava) ? lava : null),
+            NormalMap = NormalizeOptional(SafeString(payload.TryGetValue("normal_map", out var normal) ? normal : null, string.Empty)),
+            ReceiveShadows = ParseBool(payload.TryGetValue("receive_shadows", out var shadows) ? shadows : null, true),
+        };
+
+        _states[state.Name] = state;
+        var stem = Path.GetFileNameWithoutExtension(state.Name);
+        if (!string.IsNullOrEmpty(stem) && !_states.ContainsKey(stem))
+        {
+            _aliases[stem] = state.Name;
+        }
+    }
+
+    private static string SafeString(object? value, string fallback)
+    {
+        if (value is null)
+        {
+            return fallback;
+        }
+        var text = value.ToString();
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return fallback;
+        }
+        return text.Trim();
+    }
+
+    private static string? NormalizeOptional(string value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static bool ParseBool(object? value, bool defaultValue = false)
+    {
+        if (value is null)
+        {
+            return defaultValue;
+        }
+        if (value is bool b)
+        {
+            return b;
+        }
+        if (value is int i)
+        {
+            return i != 0;
+        }
+        if (value is JsonValue jsonValue)
+        {
+            if (jsonValue.TryGetValue(out bool boolValue))
+            {
+                return boolValue;
+            }
+            if (jsonValue.TryGetValue(out string? stringValue))
+            {
+                return ParseBool(stringValue, defaultValue);
+            }
+        }
+        if (value is string text)
+        {
+            var lowered = text.Trim().ToLowerInvariant();
+            return lowered switch
+            {
+                "1" or "true" or "yes" or "on" => true,
+                "0" or "false" or "no" or "off" => false,
+                _ => defaultValue,
+            };
+        }
+        return defaultValue;
+    }
+
+    private static float ParseFloat(object? value, float defaultValue = 0f)
+    {
+        if (value is null)
+        {
+            return defaultValue;
+        }
+        if (value is float f)
+        {
+            return f;
+        }
+        if (value is double d)
+        {
+            return (float)d;
+        }
+        if (value is int i)
+        {
+            return i;
+        }
+        if (value is JsonValue jsonValue)
+        {
+            if (jsonValue.TryGetValue(out float floatValue))
+            {
+                return floatValue;
+            }
+            if (jsonValue.TryGetValue(out double doubleValue))
+            {
+                return (float)doubleValue;
+            }
+            if (jsonValue.TryGetValue(out string? stringValue))
+            {
+                return ParseFloat(stringValue, defaultValue);
+            }
+        }
+        if (value is string text && float.TryParse(text, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+        return defaultValue;
+    }
+
+    private static (float, float, float) ParseVec3(object? value)
+    {
+        if (value is null)
+        {
+            return (0f, 0f, 0f);
+        }
+        if (value is JsonArray jsonArray && jsonArray.Count >= 3)
+        {
+            return (
+                ParseFloat(jsonArray[0], 0f),
+                ParseFloat(jsonArray[1], 0f),
+                ParseFloat(jsonArray[2], 0f));
+        }
+        if (value is IEnumerable<object?> enumerable)
+        {
+            var parts = enumerable.Take(3).Select(v => ParseFloat(v, 0f)).ToArray();
+            if (parts.Length == 3)
+            {
+                return (parts[0], parts[1], parts[2]);
+            }
+        }
+        if (value is string text)
+        {
+            var tokens = text.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length >= 3)
+            {
+                return (
+                    ParseFloat(tokens[0], 0f),
+                    ParseFloat(tokens[1], 0f),
+                    ParseFloat(tokens[2], 0f));
+            }
+        }
+        return (0f, 0f, 0f);
+    }
+
+    private static string NormalizeKey(string textureName)
+    {
+        var text = textureName.Replace('\\', '/');
+        foreach (var ext in new[] { ".ozj", ".ozt", ".jpg", ".jpeg", ".png", ".tga", ".bmp", ".dds" })
+        {
+            if (text.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
+            {
+                text = text[..^ext.Length];
+            }
+        }
+        return text.ToLowerInvariant();
+    }
+
+    private static MaterialState BuildFallback(string textureName)
+    {
+        var lowered = textureName.ToLowerInvariant();
+        var state = new MaterialState
+        {
+            Name = NormalizeKey(textureName),
+            Transparent = lowered.Contains("alpha") || lowered.Contains("glass"),
+            Additive = lowered.Contains("glow") || lowered.Contains("flare"),
+            Water = lowered.Contains("water") || lowered.Contains("river") || lowered.Contains("ocean"),
+            Lava = lowered.Contains("lava") || lowered.Contains("magma"),
+            ReceiveShadows = !lowered.Contains("shadow"),
+        };
+        if (state.Water)
+        {
+            state = state with
+            {
+                Transparent = true,
+                DepthWrite = false,
+                SrcBlend = "src_alpha",
+                DstBlend = "one_minus_src_alpha",
+            };
+        }
+        if (state.Lava)
+        {
+            state = state with
+            {
+                Transparent = true,
+                Additive = true,
+                Emissive = (0.6f, 0.3f, 0.1f),
+            };
+        }
+        if (lowered.Contains("emissive") || lowered.Contains("light"))
+        {
+            state = state with { Emissive = (0.6f, 0.6f, 0.6f) };
+        }
+        return state;
+    }
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/TextureImage.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/TextureImage.cs
@@ -1,0 +1,409 @@
+using System.Buffers.Binary;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+
+namespace TerrenoVisualisado.Core;
+
+public sealed class TextureImage
+{
+    public TextureImage(int width, int height, byte[] pixels)
+    {
+        Width = width;
+        Height = height;
+        Pixels = pixels;
+    }
+
+    public int Width { get; }
+    public int Height { get; }
+    public byte[] Pixels { get; }
+
+    public TextureImage Resize(int targetWidth, int targetHeight)
+    {
+        if (targetWidth <= 0 || targetHeight <= 0)
+        {
+            throw new ArgumentOutOfRangeException("targetWidth");
+        }
+        if (targetWidth == Width && targetHeight == Height)
+        {
+            return this;
+        }
+
+        var result = new byte[targetWidth * targetHeight * 4];
+        var scaleX = (float)Width / targetWidth;
+        var scaleY = (float)Height / targetHeight;
+        for (var y = 0; y < targetHeight; y++)
+        {
+            var srcY = (y + 0.5f) * scaleY - 0.5f;
+            for (var x = 0; x < targetWidth; x++)
+            {
+                var srcX = (x + 0.5f) * scaleX - 0.5f;
+                var color = SampleBilinear(srcX, srcY);
+                var offset = (y * targetWidth + x) * 4;
+                result[offset + 0] = color[0];
+                result[offset + 1] = color[1];
+                result[offset + 2] = color[2];
+                result[offset + 3] = color[3];
+            }
+        }
+        return new TextureImage(targetWidth, targetHeight, result);
+    }
+
+    public Bitmap ToBitmap()
+    {
+        var bitmap = new Bitmap(Width, Height, PixelFormat.Format32bppArgb);
+        var data = bitmap.LockBits(new Rectangle(0, 0, Width, Height), ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
+        try
+        {
+            for (var y = 0; y < Height; y++)
+            {
+                var srcOffset = y * Width * 4;
+                var dstPtr = IntPtr.Add(data.Scan0, y * data.Stride);
+                Marshal.Copy(Pixels, srcOffset, dstPtr, Width * 4);
+            }
+        }
+        finally
+        {
+            bitmap.UnlockBits(data);
+        }
+        return bitmap;
+    }
+
+    public void SavePng(string path)
+    {
+        using var bitmap = ToBitmap();
+        bitmap.Save(path, ImageFormat.Png);
+    }
+
+    private byte[] SampleBilinear(float x, float y)
+    {
+        x = Math.Clamp(x, 0f, Width - 1);
+        y = Math.Clamp(y, 0f, Height - 1);
+        var x0 = (int)Math.Floor(x);
+        var y0 = (int)Math.Floor(y);
+        var x1 = Math.Min(x0 + 1, Width - 1);
+        var y1 = Math.Min(y0 + 1, Height - 1);
+        var tx = x - x0;
+        var ty = y - y0;
+        Span<float> accum = stackalloc float[4];
+        Span<byte> c00 = stackalloc byte[4];
+        Span<byte> c10 = stackalloc byte[4];
+        Span<byte> c01 = stackalloc byte[4];
+        Span<byte> c11 = stackalloc byte[4];
+        ReadPixel(x0, y0, c00);
+        ReadPixel(x1, y0, c10);
+        ReadPixel(x0, y1, c01);
+        ReadPixel(x1, y1, c11);
+        Span<byte> result = stackalloc byte[4];
+        for (var i = 0; i < 4; i++)
+        {
+            accum[i] = c00[i] * (1 - tx) * (1 - ty)
+                + c10[i] * tx * (1 - ty)
+                + c01[i] * (1 - tx) * ty
+                + c11[i] * tx * ty;
+            result[i] = (byte)Math.Clamp((int)Math.Round(accum[i]), 0, 255);
+        }
+        return result.ToArray();
+    }
+
+    private void ReadPixel(int x, int y, Span<byte> destination)
+    {
+        var offset = (y * Width + x) * 4;
+        destination[0] = Pixels[offset + 0];
+        destination[1] = Pixels[offset + 1];
+        destination[2] = Pixels[offset + 2];
+        destination[3] = Pixels[offset + 3];
+    }
+
+    public static TextureImage FromRgba(int width, int height, byte[] pixels)
+    {
+        return new TextureImage(width, height, pixels);
+    }
+}
+
+internal static class TextureFileLoader
+{
+    private static readonly string[] ImageExtensions =
+    {
+        ".ozj",
+        ".ozt",
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".tga",
+        ".bmp",
+    };
+
+    public static bool TryLoad(string path, out TextureImage? image)
+    {
+        image = null;
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        var extension = Path.GetExtension(path);
+        if (string.Equals(extension, ".ozj", StringComparison.OrdinalIgnoreCase))
+        {
+            image = LoadOzj(path);
+            return image != null;
+        }
+        if (string.Equals(extension, ".ozt", StringComparison.OrdinalIgnoreCase))
+        {
+            image = LoadOzt(path);
+            return image != null;
+        }
+        if (string.Equals(extension, ".tga", StringComparison.OrdinalIgnoreCase))
+        {
+            image = LoadTga(File.ReadAllBytes(path));
+            return image != null;
+        }
+
+        using var stream = File.OpenRead(path);
+        using var bitmap = (Bitmap)Image.FromStream(stream);
+        return TryFromBitmap(bitmap, out image);
+    }
+
+    public static IEnumerable<string> EnumerateCandidatePaths(string root, string baseName)
+    {
+        if (!Directory.Exists(root))
+        {
+            yield break;
+        }
+
+        var normalized = baseName.Replace('\\', '/');
+        var variants = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            baseName,
+            normalized,
+            normalized.ToLowerInvariant(),
+            normalized.ToUpperInvariant(),
+        };
+
+        foreach (var variant in variants)
+        {
+            var direct = Path.Combine(root, variant);
+            if (File.Exists(direct))
+            {
+                yield return direct;
+            }
+            foreach (var ext in ImageExtensions)
+            {
+                var withExt = Path.Combine(root, variant + ext);
+                if (File.Exists(withExt))
+                {
+                    yield return withExt;
+                }
+                var alt = Path.Combine(root, variant + "." + ext.TrimStart('.'));
+                if (File.Exists(alt))
+                {
+                    yield return alt;
+                }
+            }
+        }
+    }
+
+    private static TextureImage? LoadOzj(string path)
+    {
+        var data = File.ReadAllBytes(path);
+        if (data.Length <= 24)
+        {
+            return null;
+        }
+        using var stream = new MemoryStream(data, 24, data.Length - 24, writable: false);
+        using var bitmap = (Bitmap)Image.FromStream(stream);
+        return TryFromBitmap(bitmap, out var image) ? image : null;
+    }
+
+    private static TextureImage? LoadOzt(string path)
+    {
+        var data = File.ReadAllBytes(path);
+        if (data.Length <= 4)
+        {
+            return null;
+        }
+        var tgaData = data.AsSpan(4).ToArray();
+        return LoadTga(tgaData);
+    }
+
+    private static TextureImage? LoadTga(byte[] data)
+    {
+        if (data.Length < 18)
+        {
+            return null;
+        }
+        var idLength = data[0];
+        var colorMapType = data[1];
+        var imageType = data[2];
+        if (colorMapType != 0 || (imageType != 2 && imageType != 3 && imageType != 10))
+        {
+            return null;
+        }
+        var width = BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(12));
+        var height = BinaryPrimitives.ReadUInt16LittleEndian(data.AsSpan(14));
+        var bpp = data[16];
+        var descriptor = data[17];
+        var originTop = (descriptor & 0x20) != 0;
+        var originLeft = (descriptor & 0x10) == 0;
+        var offset = 18 + idLength;
+        if (width <= 0 || height <= 0)
+        {
+            return null;
+        }
+        if (imageType == 10)
+        {
+            // RLE compressed: expand
+            var pixels = new byte[width * height * 4];
+            var index = 0;
+            while (index < pixels.Length && offset < data.Length)
+            {
+                var packet = data[offset++];
+                var count = (packet & 0x7F) + 1;
+                if ((packet & 0x80) != 0)
+                {
+                    if (!ReadBgr(data, ref offset, bpp, out var color))
+                    {
+                        break;
+                    }
+                    for (var i = 0; i < count && index < pixels.Length; i++)
+                    {
+                        WritePixel(pixels, ref index, color);
+                    }
+                }
+                else
+                {
+                    for (var i = 0; i < count && index < pixels.Length; i++)
+                    {
+                        if (!ReadBgr(data, ref offset, bpp, out var color))
+                        {
+                            index = pixels.Length;
+                            break;
+                        }
+                        WritePixel(pixels, ref index, color);
+                    }
+                }
+            }
+            ReorderTga(pixels, width, height, originLeft, originTop);
+            return new TextureImage(width, height, pixels);
+        }
+        else
+        {
+            var expected = width * height * (bpp / 8);
+            if (offset + expected > data.Length)
+            {
+                return null;
+            }
+            var pixels = new byte[width * height * 4];
+            var index = 0;
+            for (var i = 0; i < width * height; i++)
+            {
+                if (!ReadBgr(data, ref offset, bpp, out var color))
+                {
+                    return null;
+                }
+                WritePixel(pixels, ref index, color);
+            }
+            ReorderTga(pixels, width, height, originLeft, originTop);
+            return new TextureImage(width, height, pixels);
+        }
+    }
+
+    private static void ReorderTga(byte[] pixels, int width, int height, bool originLeft, bool originTop)
+    {
+        if (!originLeft)
+        {
+            FlipHorizontal(pixels, width, height);
+        }
+        if (!originTop)
+        {
+            FlipVertical(pixels, width, height);
+        }
+    }
+
+    private static void FlipHorizontal(byte[] pixels, int width, int height)
+    {
+        var stride = width * 4;
+        for (var y = 0; y < height; y++)
+        {
+            var row = y * stride;
+            for (var x = 0; x < width / 2; x++)
+            {
+                var left = row + x * 4;
+                var right = row + (width - 1 - x) * 4;
+                for (var i = 0; i < 4; i++)
+                {
+                    (pixels[left + i], pixels[right + i]) = (pixels[right + i], pixels[left + i]);
+                }
+            }
+        }
+    }
+
+    private static void FlipVertical(byte[] pixels, int width, int height)
+    {
+        var stride = width * 4;
+        for (var y = 0; y < height / 2; y++)
+        {
+            var top = y * stride;
+            var bottom = (height - 1 - y) * stride;
+            for (var x = 0; x < stride; x++)
+            {
+                (pixels[top + x], pixels[bottom + x]) = (pixels[bottom + x], pixels[top + x]);
+            }
+        }
+    }
+
+    private static bool ReadBgr(byte[] data, ref int offset, int bpp, out (byte B, byte G, byte R, byte A) color)
+    {
+        color = default;
+        var bytesPerPixel = bpp / 8;
+        if (bytesPerPixel < 3 || offset + bytesPerPixel > data.Length)
+        {
+            return false;
+        }
+        var b = data[offset + 0];
+        var g = data[offset + 1];
+        var r = data[offset + 2];
+        byte a = 255;
+        if (bytesPerPixel >= 4)
+        {
+            a = data[offset + 3];
+        }
+        offset += bytesPerPixel;
+        color = (b, g, r, a);
+        return true;
+    }
+
+    private static void WritePixel(byte[] pixels, ref int index, (byte B, byte G, byte R, byte A) color)
+    {
+        if (index + 4 > pixels.Length)
+        {
+            return;
+        }
+        pixels[index++] = color.R;
+        pixels[index++] = color.G;
+        pixels[index++] = color.B;
+        pixels[index++] = color.A;
+    }
+
+    private static bool TryFromBitmap(Bitmap bitmap, out TextureImage? image)
+    {
+        image = null;
+        var rect = new Rectangle(0, 0, bitmap.Width, bitmap.Height);
+        var data = bitmap.LockBits(rect, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+        try
+        {
+            var buffer = new byte[bitmap.Width * bitmap.Height * 4];
+            for (var y = 0; y < bitmap.Height; y++)
+            {
+                var srcPtr = IntPtr.Add(data.Scan0, y * data.Stride);
+                Marshal.Copy(srcPtr, buffer, y * bitmap.Width * 4, bitmap.Width * 4);
+            }
+            image = new TextureImage(bitmap.Width, bitmap.Height, buffer);
+            return true;
+        }
+        finally
+        {
+            bitmap.UnlockBits(data);
+        }
+    }
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/TextureLibrary.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/TextureLibrary.cs
@@ -1,0 +1,255 @@
+namespace TerrenoVisualisado.Core;
+
+public sealed class TextureLibrary
+{
+    private static readonly Dictionary<int, string[]> TileTextureCandidates = new()
+    {
+        [0] = new[] { "TileGrass01", "TileGrass01_R" },
+        [1] = new[] { "TileGrass02" },
+        [2] = new[] { "TileGround01", "AlphaTileGround01", "AlphaTile01" },
+        [3] = new[] { "TileGround02", "AlphaTileGround02" },
+        [4] = new[] { "TileGround03", "AlphaTileGround03" },
+        [5] = new[] { "TileWater01", "Object25/water1", "Object25/water2" },
+        [6] = new[] { "TileWood01" },
+        [7] = new[] { "TileRock01" },
+        [8] = new[] { "TileRock02" },
+        [9] = new[] { "TileRock03" },
+        [10] = new[] { "TileRock04", "AlphaTile01" },
+        [11] = new[] { "TileRock05", "Object64/song_lava1" },
+        [12] = new[] { "TileRock06", "AlphaTile01" },
+        [13] = new[] { "TileRock07" },
+    };
+
+    static TextureLibrary()
+    {
+        for (var ext = 1; ext <= 16; ext++)
+        {
+            TileTextureCandidates[13 + ext] = new[] { $"ExtTile{ext:00}" };
+        }
+    }
+
+    private readonly List<string> _searchRoots;
+    private readonly Dictionary<int, TextureImage?> _cache = new();
+    private readonly Dictionary<(int Index, int Size), TextureImage> _resized = new();
+    private readonly HashSet<int> _missing = new();
+    private readonly Dictionary<int, string> _resolvedPaths = new();
+    private readonly int _detailFactor;
+
+    public TextureLibrary(string worldDirectory, string? objectDirectory, int? mapId, int detailFactor = 2)
+    {
+        _detailFactor = Math.Max(1, detailFactor);
+        _searchRoots = BuildSearchRoots(worldDirectory, objectDirectory, mapId);
+    }
+
+    public IReadOnlyCollection<int> MissingIndices => _missing;
+
+    public string? GetResolvedPath(int index)
+    {
+        return _resolvedPaths.TryGetValue(index, out var path) ? path : null;
+    }
+
+    public string? GetTileTextureName(int index)
+    {
+        if (TileTextureCandidates.TryGetValue(index, out var candidates) && candidates.Length > 0)
+        {
+            return candidates[0];
+        }
+        return $"ExtTile{index:00}";
+    }
+
+    public TextureImage ComposeLayeredTexture(byte[] layer1, byte[] layer2, float[] alpha)
+    {
+        var size = WorldLoader.TerrainSize;
+        if (layer1.Length != size * size || layer2.Length != size * size || alpha.Length != size * size)
+        {
+            throw new ArgumentException("Camadas inválidas");
+        }
+
+        var patch = _detailFactor;
+        var width = size * patch;
+        var pixels = new byte[width * width * 4];
+
+        for (var tileY = 0; tileY < size; tileY++)
+        {
+            for (var tileX = 0; tileX < size; tileX++)
+            {
+                var tileIndex = tileY * size + tileX;
+                var baseIndex = layer1[tileIndex];
+                var overlayIndex = layer2[tileIndex];
+                var alphaValue = alpha[tileIndex];
+                var basePatch = ResolvePatch(baseIndex, patch);
+                var overlayPatch = overlayIndex != 255 ? ResolvePatch(overlayIndex, patch) : null;
+                var mode = overlayPatch is not null && alphaValue >= 0.999f ? 2 : (overlayPatch is not null && alphaValue > 0f ? 1 : 0);
+                BlendTile(pixels, basePatch, overlayPatch, alphaValue, mode, width, patch, tileX, tileY);
+            }
+        }
+
+        return new TextureImage(width, width, pixels);
+    }
+
+    private void BlendTile(byte[] canvas, TextureImage basePatch, TextureImage? overlay, float alpha, int mode, int canvasWidth, int patchSize, int tileX, int tileY)
+    {
+        var startX = tileX * patchSize;
+        var startY = tileY * patchSize;
+        for (var y = 0; y < patchSize; y++)
+        {
+            for (var x = 0; x < patchSize; x++)
+            {
+                var canvasOffset = ((startY + y) * canvasWidth + (startX + x)) * 4;
+                var baseOffset = (y * patchSize + x) * 4;
+                var r = basePatch.Pixels[baseOffset + 0];
+                var g = basePatch.Pixels[baseOffset + 1];
+                var b = basePatch.Pixels[baseOffset + 2];
+                var a = basePatch.Pixels[baseOffset + 3];
+                if (overlay is not null && mode != 0)
+                {
+                    var overlayOffset = baseOffset;
+                    var or = overlay.Pixels[overlayOffset + 0];
+                    var og = overlay.Pixels[overlayOffset + 1];
+                    var ob = overlay.Pixels[overlayOffset + 2];
+                    var oa = overlay.Pixels[overlayOffset + 3];
+                    if (mode == 2)
+                    {
+                        r = or; g = og; b = ob; a = oa;
+                    }
+                    else
+                    {
+                        var blend = Math.Clamp(alpha, 0f, 1f);
+                        r = (byte)Math.Clamp((int)Math.Round(r * (1 - blend) + or * blend), 0, 255);
+                        g = (byte)Math.Clamp((int)Math.Round(g * (1 - blend) + og * blend), 0, 255);
+                        b = (byte)Math.Clamp((int)Math.Round(b * (1 - blend) + ob * blend), 0, 255);
+                        a = (byte)Math.Clamp((int)Math.Round(a * (1 - blend) + oa * blend), 0, 255);
+                    }
+                }
+                canvas[canvasOffset + 0] = r;
+                canvas[canvasOffset + 1] = g;
+                canvas[canvasOffset + 2] = b;
+                canvas[canvasOffset + 3] = a;
+            }
+        }
+    }
+
+    private TextureImage ResolvePatch(int index, int patchSize)
+    {
+        var key = (index, patchSize);
+        if (_resized.TryGetValue(key, out var cached))
+        {
+            return cached;
+        }
+
+        var image = LoadTexture(index);
+        TextureImage patch;
+        if (image is null)
+        {
+            var fallback = BuildFallbackColor(index);
+            patch = TextureImage.FromRgba(patchSize, patchSize, fallback);
+        }
+        else
+        {
+            patch = image.Resize(patchSize, patchSize);
+        }
+        _resized[key] = patch;
+        return patch;
+    }
+
+    private TextureImage? LoadTexture(int index)
+    {
+        if (_cache.TryGetValue(index, out var cached))
+        {
+            return cached;
+        }
+
+        var candidates = TileTextureCandidates.TryGetValue(index, out var list) ? list : Array.Empty<string>();
+        if (candidates.Length == 0)
+        {
+            candidates = new[] { $"ExtTile{index:00}" };
+        }
+
+        foreach (var candidate in candidates)
+        {
+            foreach (var root in _searchRoots)
+            {
+                foreach (var path in TextureFileLoader.EnumerateCandidatePaths(root, candidate))
+                {
+                    if (TextureFileLoader.TryLoad(path, out var image))
+                    {
+                        _cache[index] = image;
+                        _resolvedPaths[index] = path;
+                        return image;
+                    }
+                }
+            }
+        }
+
+        _missing.Add(index);
+        _cache[index] = null;
+        return null;
+    }
+
+    private static byte[] BuildFallbackColor(int index)
+    {
+        var random = (index * 2654435761u) ^ 0xA53B5E2Du;
+        var r = (byte)(random & 0xFF);
+        var g = (byte)((random >> 8) & 0xFF);
+        var b = (byte)((random >> 16) & 0xFF);
+        var a = (byte)255;
+        var size = 4;
+        var buffer = new byte[size * size * 4];
+        for (var i = 0; i < size * size; i++)
+        {
+            var offset = i * 4;
+            buffer[offset + 0] = r;
+            buffer[offset + 1] = g;
+            buffer[offset + 2] = b;
+            buffer[offset + 3] = a;
+        }
+        return buffer;
+    }
+
+    private static List<string> BuildSearchRoots(string worldDirectory, string? objectDirectory, int? mapId)
+    {
+        var roots = new List<string>();
+        void Add(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+            var full = Path.GetFullPath(path);
+            if (Directory.Exists(full) && !roots.Contains(full, StringComparer.OrdinalIgnoreCase))
+            {
+                roots.Add(full);
+            }
+        }
+
+        Add(worldDirectory);
+        var worldParent = Directory.GetParent(worldDirectory);
+        if (worldParent != null)
+        {
+            Add(worldParent.FullName);
+            foreach (var child in worldParent.EnumerateDirectories())
+            {
+                var name = child.Name.ToLowerInvariant();
+                if (name.StartsWith("world") || name.StartsWith("object") || name.StartsWith("texture"))
+                {
+                    Add(child.FullName);
+                }
+            }
+        }
+        Add(objectDirectory);
+
+        if (mapId.HasValue && worldParent != null)
+        {
+            var digits = mapId.Value.ToString();
+            foreach (var child in worldParent.EnumerateDirectories())
+            {
+                if (child.Name.Contains(digits, StringComparison.OrdinalIgnoreCase))
+                {
+                    Add(child.FullName);
+                }
+            }
+        }
+
+        return roots;
+    }
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldExporter.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldExporter.cs
@@ -6,6 +6,65 @@ public static class WorldExporter
 {
     public static void WriteJson(WorldData world, string outputPath)
     {
+        var fullOutputPath = Path.GetFullPath(outputPath);
+        var outputDirectory = Path.GetDirectoryName(fullOutputPath);
+        if (!string.IsNullOrEmpty(outputDirectory))
+        {
+            Directory.CreateDirectory(outputDirectory);
+        }
+
+        string? textureAtlasRelative = null;
+        if (world.Visual?.CompositeTexture is TextureImage atlas)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(fullOutputPath) ?? "terrainsummary";
+            var textureFileName = baseName + "_texture.png";
+            var texturePath = string.IsNullOrEmpty(outputDirectory)
+                ? textureFileName
+                : Path.Combine(outputDirectory, textureFileName);
+            atlas.SavePng(texturePath);
+            textureAtlasRelative = textureFileName;
+        }
+
+        var visualPayload = world.Visual is null
+            ? null
+            : new
+            {
+                TextureAtlas = textureAtlasRelative,
+                TileTextures = world.Visual.TileTextures.ToDictionary(kv => (int)kv.Key, kv => kv.Value),
+                TileMaterialFlags = world.Visual.TileMaterialFlags.ToDictionary(
+                    kv => (int)kv.Key,
+                    kv => new
+                    {
+                        Numeric = (uint)kv.Value,
+                        Flags = kv.Value.ToString(),
+                    }),
+                world.Visual.MaterialFlagsPerTile,
+                MissingTileIndices = world.Visual.MissingTileIndices,
+            };
+
+        var modelsPayload = world.ModelLibrary.Models.ToDictionary(
+            kv => (int)kv.Key,
+            kv => new
+            {
+                kv.Value.Name,
+                kv.Value.Version,
+                kv.Value.SourcePath,
+                Meshes = kv.Value.Meshes.Select(mesh => new
+                {
+                    mesh.Name,
+                    mesh.TextureName,
+                    MaterialFlags = new
+                    {
+                        Numeric = (uint)mesh.MaterialFlags,
+                        Flags = mesh.MaterialFlags.ToString(),
+                    },
+                    mesh.Positions,
+                    mesh.Normals,
+                    mesh.TexCoords,
+                    mesh.Indices,
+                }),
+            });
+
         var export = new
         {
             world.WorldPath,
@@ -30,12 +89,18 @@ public static class WorldExporter
                 Rotation = new[] { obj.Rotation.X, obj.Rotation.Y, obj.Rotation.Z },
                 obj.Scale,
             }),
+            Visual = visualPayload,
+            Models = new
+            {
+                Loaded = modelsPayload,
+                Failures = world.ModelLibrary.Failures.ToDictionary(kv => (int)kv.Key, kv => kv.Value),
+            },
         };
 
         var options = new JsonSerializerOptions
         {
             WriteIndented = true,
         };
-        File.WriteAllText(outputPath, JsonSerializer.Serialize(export, options));
+        File.WriteAllText(fullOutputPath, JsonSerializer.Serialize(export, options));
     }
 }

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldVisualData.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldVisualData.cs
@@ -1,0 +1,16 @@
+namespace TerrenoVisualisado.Core;
+
+public sealed class TerrainVisualData
+{
+    public TextureImage? CompositeTexture { get; init; }
+    public IReadOnlyDictionary<byte, string?> TileTextures { get; init; } = new Dictionary<byte, string?>();
+    public IReadOnlyDictionary<byte, MaterialFlags> TileMaterialFlags { get; init; } = new Dictionary<byte, MaterialFlags>();
+    public uint[] MaterialFlagsPerTile { get; init; } = Array.Empty<uint>();
+    public IReadOnlyCollection<int> MissingTileIndices { get; init; } = Array.Empty<int>();
+}
+
+public sealed class ModelLibraryData
+{
+    public IReadOnlyDictionary<short, BmdModel> Models { get; init; } = new Dictionary<short, BmdModel>();
+    public IReadOnlyDictionary<short, string> Failures { get; init; } = new Dictionary<short, string>();
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Gui/TerrainPreviewRenderer.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Gui/TerrainPreviewRenderer.cs
@@ -20,6 +20,15 @@ internal static class TerrainPreviewRenderer
     public static Bitmap Render(WorldData world, PreviewMode mode, bool overlayObjects)
     {
         var size = WorldLoader.TerrainSize;
+        if (mode == PreviewMode.Layer1 && world.Visual?.CompositeTexture is { } composite)
+        {
+            var bitmap = composite.ToBitmap();
+            if (overlayObjects)
+            {
+                OverlayObjects(world, bitmap);
+            }
+            return bitmap;
+        }
         var bitmap = new Bitmap(size, size, PixelFormat.Format32bppArgb);
         var rect = new Rectangle(0, 0, size, size);
         var data = bitmap.LockBits(rect, ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
@@ -55,20 +64,26 @@ internal static class TerrainPreviewRenderer
 
         if (overlayObjects)
         {
-            using var g = Graphics.FromImage(bitmap);
-            using var brush = new SolidBrush(Color.FromArgb(192, Color.Red));
-            foreach (var obj in world.Objects)
-            {
-                var px = obj.RawPosition.X / 100f;
-                var py = obj.RawPosition.Y / 100f;
-                var x = Math.Clamp((int)MathF.Round(px), 0, size - 1);
-                var y = Math.Clamp((int)MathF.Round(py), 0, size - 1);
-                var screenY = size - 1 - y;
-                g.FillEllipse(brush, x - 2, screenY - 2, 4, 4);
-            }
+            OverlayObjects(world, bitmap);
         }
 
         return bitmap;
+    }
+
+    private static void OverlayObjects(WorldData world, Bitmap bitmap)
+    {
+        var size = WorldLoader.TerrainSize;
+        using var g = Graphics.FromImage(bitmap);
+        using var brush = new SolidBrush(Color.FromArgb(192, Color.Red));
+        foreach (var obj in world.Objects)
+        {
+            var px = obj.RawPosition.X / 100f;
+            var py = obj.RawPosition.Y / 100f;
+            var x = Math.Clamp((int)MathF.Round(px), 0, size - 1);
+            var y = Math.Clamp((int)MathF.Round(py), 0, size - 1);
+            var screenY = size - 1 - y;
+            g.FillEllipse(brush, x - 2, screenY - 2, 4, 4);
+        }
     }
 
     private static void RenderHeight(float[] height, byte[] buffer, int stride, int size)


### PR DESCRIPTION
## Summary
- add material, texture and BMD loading helpers so the CLI reconstructs real map visuals and models
- export composite terrain textures, per-tile material flags and loaded model meshes in the generated JSON bundle
- update the WinForms preview to render the true textured atlas while keeping overlays and CLI summary improvements

## Testing
- Not run (dotnet SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e66ea2cb6c833288def32aecdcc981