### PR TITLE
Add TerrainLight and water context support to terrain visualizer

### DIFF
--- a/tools/terreno_visualisado/Program.cs
+++ b/tools/terreno_visualisado/Program.cs
@@ -89,6 +89,21 @@ internal static class Program
             var waterTiles = visual.MaterialFlagsPerTile.Count(flag => (flag & (uint)MaterialFlags.Water) != 0);
             var lavaTiles = visual.MaterialFlagsPerTile.Count(flag => (flag & (uint)MaterialFlags.Lava) != 0);
             Console.WriteLine($"Tiles com água: {waterTiles}, lava: {lavaTiles}");
+            if (visual.LightMap is not null)
+            {
+                Console.WriteLine($"TerrainLight aplicado: {visual.LightMapPath ?? "arquivo detectado"}");
+            }
+            else
+            {
+                Console.WriteLine("TerrainLight aplicado: nenhum arquivo encontrado");
+            }
+            Console.WriteLine($"Mapa com CreateWaterTerrain: {(visual.HasWaterTerrain ? "sim" : "não")}");
+            if (visual.SpecialTextures.Count > 0)
+            {
+                var loaded = visual.SpecialTextures.Count(kv => !string.IsNullOrEmpty(kv.Value));
+                var missing = visual.SpecialTextures.Count - loaded;
+                Console.WriteLine($"Texturas especiais carregadas: {loaded}, ausentes: {missing}");
+            }
         }
 
         Console.WriteLine($"Modelos BMD carregados: {world.ModelLibrary.Models.Count} (falhas: {world.ModelLibrary.Failures.Count})");

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/MapContext.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/MapContext.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+
+namespace TerrenoVisualisado.Core;
+
+public readonly struct MapContext
+{
+    public const int InvalidMapId = -1;
+
+    public MapContext(int mapId)
+    {
+        MapId = mapId;
+    }
+
+    public int MapId { get; }
+
+    public bool HasValidMapId => MapId >= 0;
+
+    public static MapContext ForMapId(int? mapId)
+    {
+        return new MapContext(mapId ?? InvalidMapId);
+    }
+
+    public bool IsBattleCastle => MapId == (int)MapIdConstants.BattleCastle;
+    public bool IsCryWolf => MapId == (int)MapIdConstants.CryWolfFirst;
+    public bool IsKanturuThird => MapId == (int)MapIdConstants.KanturuThird;
+    public bool IsPkField => MapId == (int)MapIdConstants.PkField;
+    public bool IsDoppelGanger2 => MapId == (int)MapIdConstants.DoppelGanger2;
+    public bool IsKarutan => MapId == (int)MapIdConstants.Karutan1 || MapId == (int)MapIdConstants.Karutan2;
+    public bool IsCursedTemple => MapId >= (int)MapIdConstants.CursedTempleLevel1 && MapId <= (int)MapIdConstants.CursedTempleLevel6;
+    public bool IsHome6thCharacter => MapId == (int)MapIdConstants.Home6thCharacter;
+    public bool IsNewLoginScene => MapId == (int)MapIdConstants.NewLoginScene73 || MapId == (int)MapIdConstants.NewLoginScene77;
+    public bool IsNewCharacterScene => MapId == (int)MapIdConstants.NewCharacterScene74 || MapId == (int)MapIdConstants.NewCharacterScene78;
+    public bool IsEmpireGuardian => MapId >= (int)MapIdConstants.EmpireGuardian1 && MapId <= (int)MapIdConstants.EmpireGuardian4 || IsNewLoginScene || IsNewCharacterScene;
+
+    public bool HasWaterTerrain => MapId >= (int)MapIdConstants.Hellas && MapId <= (int)MapIdConstants.HellasEnd || MapId == (int)MapIdConstants.HellasHidden;
+
+    public IEnumerable<string> EnumerateTerrainLightCandidates()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return Enumerate();
+
+        IEnumerable<string> Enumerate()
+        {
+            if (IsBattleCastle && seen.Add("TerrainLight2"))
+            {
+                yield return "TerrainLight2";
+            }
+
+            if (seen.Add("TerrainLight"))
+            {
+                yield return "TerrainLight";
+            }
+
+            if (IsCryWolf && seen.Add("TerrainLight1"))
+            {
+                yield return "TerrainLight1";
+            }
+
+            if (IsCryWolf && seen.Add("TerrainLight2"))
+            {
+                yield return "TerrainLight2";
+            }
+
+            if (seen.Add("TerrainLight1"))
+            {
+                yield return "TerrainLight1";
+            }
+
+            if (seen.Add("TerrainLight2"))
+            {
+                yield return "TerrainLight2";
+            }
+        }
+    }
+
+    public bool UsesAlphaGround01 => IsHome6thCharacter || IsNewLoginScene || IsNewCharacterScene;
+    public bool UsesAlphaTileForRock04 => IsEmpireGuardian || IsNewLoginScene || IsNewCharacterScene;
+
+    private enum MapIdConstants
+    {
+        Hellas = 24,
+        HellasEnd = Hellas + 5,
+        HellasHidden = 36,
+        BattleCastle = 30,
+        CryWolfFirst = 34,
+        KanturuThird = 39,
+        CursedTempleLevel1 = 45,
+        CursedTempleLevel6 = 50,
+        Home6thCharacter = 51,
+        NewLoginScene73 = 73,
+        NewCharacterScene74 = 74,
+        NewLoginScene77 = 77,
+        NewCharacterScene78 = 78,
+        PkField = 63,
+        DoppelGanger2 = 66,
+        EmpireGuardian1 = 69,
+        EmpireGuardian2 = 70,
+        EmpireGuardian3 = 71,
+        EmpireGuardian4 = 72,
+        Karutan1 = 80,
+        Karutan2 = 81,
+    }
+}

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldExporter.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldExporter.cs
@@ -25,11 +25,41 @@ public static class WorldExporter
             textureAtlasRelative = textureFileName;
         }
 
+        string? litTextureRelative = null;
+        if (world.Visual?.LitCompositeTexture is TextureImage lit)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(fullOutputPath) ?? "terrainsummary";
+            var textureFileName = baseName + "_texture_lit.png";
+            var texturePath = string.IsNullOrEmpty(outputDirectory)
+                ? textureFileName
+                : Path.Combine(outputDirectory, textureFileName);
+            lit.SavePng(texturePath);
+            litTextureRelative = textureFileName;
+        }
+
+        string? lightMapRelative = null;
+        if (world.Visual?.LightMap is TextureImage lightMap)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(fullOutputPath) ?? "terrainsummary";
+            var textureFileName = baseName + "_lightmap.png";
+            var texturePath = string.IsNullOrEmpty(outputDirectory)
+                ? textureFileName
+                : Path.Combine(outputDirectory, textureFileName);
+            lightMap.SavePng(texturePath);
+            lightMapRelative = textureFileName;
+        }
+
         var visualPayload = world.Visual is null
             ? null
             : new
             {
                 TextureAtlas = textureAtlasRelative,
+                LitTextureAtlas = litTextureRelative,
+                LightMap = new
+                {
+                    Source = world.Visual.LightMapPath,
+                    Texture = lightMapRelative,
+                },
                 TileTextures = world.Visual.TileTextures.ToDictionary(kv => (int)kv.Key, kv => kv.Value),
                 TileMaterialFlags = world.Visual.TileMaterialFlags.ToDictionary(
                     kv => (int)kv.Key,
@@ -40,6 +70,8 @@ public static class WorldExporter
                     }),
                 world.Visual.MaterialFlagsPerTile,
                 MissingTileIndices = world.Visual.MissingTileIndices,
+                HasWaterTerrain = world.Visual.HasWaterTerrain,
+                SpecialTextures = world.Visual.SpecialTextures.ToDictionary(kv => kv.Key, kv => kv.Value),
             };
 
         var modelsPayload = world.ModelLibrary.Models.ToDictionary(

--- a/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldVisualData.cs
+++ b/tools/terreno_visualisado/TerrenoVisualisado.Core/WorldVisualData.cs
@@ -3,10 +3,15 @@ namespace TerrenoVisualisado.Core;
 public sealed class TerrainVisualData
 {
     public TextureImage? CompositeTexture { get; init; }
+    public TextureImage? LitCompositeTexture { get; init; }
+    public TextureImage? LightMap { get; init; }
+    public string? LightMapPath { get; init; }
     public IReadOnlyDictionary<byte, string?> TileTextures { get; init; } = new Dictionary<byte, string?>();
     public IReadOnlyDictionary<byte, MaterialFlags> TileMaterialFlags { get; init; } = new Dictionary<byte, MaterialFlags>();
     public uint[] MaterialFlagsPerTile { get; init; } = Array.Empty<uint>();
     public IReadOnlyCollection<int> MissingTileIndices { get; init; } = Array.Empty<int>();
+    public bool HasWaterTerrain { get; init; }
+    public IReadOnlyDictionary<string, string?> SpecialTextures { get; init; } = new Dictionary<string, string?>();
 }
 
 public sealed class ModelLibraryData


### PR DESCRIPTION
## Summary
- introduce a map context helper so the terrain visualizer can mirror in-game texture rules
- load and apply TerrainLight images, special rain/leaf textures, and water-terrain awareness when composing visuals
- export the extra visual assets and expose them in the CLI summary output

## Testing
- not run (dotnet SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e67fe106cc8332bd0797b5f965d62b